### PR TITLE
feat: poll multiple batteries at once

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,115 @@
 # litime-timescaledb-inserter
-A template repository for Go projects
+
+Polls one or more LiTime LiFePO4 batteries over Bluetooth LE and writes their
+readings into TimescaleDB.
+
+## Configuration
+
+| Variable | Default | Description |
+| --- | --- | --- |
+| `LITIME_BATTERIES` | | Batteries to poll, as `id=target` pairs separated by commas. |
+| `LITIME_BATTERY_BLUETOOTH_NAME` | | Single battery by advertised name. Used only when `LITIME_BATTERIES` is unset. |
+| `TIMESCALE_CONN_STRING` | *required* | PostgreSQL/TimescaleDB connection string. |
+| `SCRAPE_INTERVAL` | `10s` | How often each battery is asked for a reading. |
+| `SCAN_TIMEOUT` | `30s` | How long to scan when resolving batteries by name. |
+| `STALE_TIMEOUT` | `90s` | How long a battery may stay silent before it is reconnected. |
+| `CALLBACK_TIMEOUT` | `5s` | Timeout for a single database insert. |
+| `READING_BUFFER_SIZE` | `256` | Queue depth between Bluetooth and the database writer. |
+| `LOG_LEVEL` | `error` | `debug`, `info`, `warn` or `error`. |
+| `METRICS_ENABLED` / `METRICS_PORT` | `true` / `8081` | Prometheus metrics endpoint. |
+| `TRACING_ENABLED` / `TRACING_SAMPLERATE` | `false` / `0.01` | OpenTelemetry tracing. |
+
+### Configuring batteries
+
+Each entry maps a battery ID to either a Bluetooth device address or an
+advertised local name:
+
+```sh
+LITIME_BATTERIES="garage=11:22:33:AA:BB:CC,shed=11:22:33:AA:BB:CD"
+```
+
+The key/value separator is `=`, not `:`, because MAC addresses are full of
+colons. The ID on the left is yours to choose and is stored with every reading,
+so keep it stable: it is the only thing tying a row to a physical battery.
+
+A value is treated as an address if it parses as one, and as an advertised name
+otherwise. Which interpretation was chosen is logged at startup:
+
+```json
+{"msg":"battery configured","battery_id":"garage","match":"address","value":"11:22:33:AA:BB:CC"}
+```
+
+Check that line if a battery is never found — a mistyped address shows up here as
+`"match":"name"`.
+
+### Prefer addresses over names
+
+Names are only usable when every battery advertises a distinct one. Batteries of
+the same model often share a name, and there is no way to tell them apart, so
+readings would be attributed to whichever the adapter happened to surface first.
+Startup fails with the addresses to use if more than one device answers to a
+configured name.
+
+To find your addresses, run the discovery example from the
+[go-litime-bluetooth](https://github.com/alpineworks/go-litime-bluetooth)
+repository on the host that has the radio:
+
+```sh
+go run ./example/multi
+```
+
+Addresses are MAC addresses on Linux but opaque CoreBluetooth UUIDs on macOS, so
+a value discovered on one operating system will not work on another.
+
+## How it works
+
+All batteries share a single Bluetooth radio, which constrains the design:
+
+- **One scan resolves every battery.** An adapter runs only one scan at a time,
+  so scanning per battery would fail outright. Batteries configured by address
+  skip scanning altogether.
+- **Connections are independent.** Each battery is supervised on its own
+  goroutine and retried with exponential backoff, so one flat or out-of-range
+  battery never stalls the others.
+- **Silence is the liveness signal.** As a Bluetooth central there is no
+  notification when a peer disappears, so a battery that has not produced a
+  reading within `STALE_TIMEOUT` is disconnected and reconnected. Keep
+  `STALE_TIMEOUT` comfortably above `SCRAPE_INTERVAL` so a single missed reply
+  does not force a reconnect.
+- **Database writes are off the Bluetooth path.** Readings go through a bounded
+  queue to a separate writer, so a slow database cannot stall notification
+  dispatch. If the queue fills, readings are dropped and counted rather than
+  queued without limit.
+
+Note that a controller supports a limited number of simultaneous LE connections,
+typically single digits, which caps how many batteries one host can poll.
+
+## Metrics
+
+Per-battery series, all labelled `battery_id`, since with several batteries the
+question is usually whether one of them has quietly died:
+
+| Metric | Description |
+| --- | --- |
+| `litime_battery_connected` | `1` while connected, `0` otherwise. |
+| `litime_battery_notifications` | Readings received. |
+| `litime_battery_reconnects` | Connections re-established. |
+| `litime_battery_readings_dropped` | Readings discarded because the queue was full. |
+| `litime_battery_parse_failures` | Notifications that could not be parsed. |
+| `litime_inserts` / `litime_insert_errors` | Database write outcomes. |
+
+## Schema
+
+Readings land in `sensors.litime`, a hypertable keyed on `time` with a
+`battery_id` column identifying the source. Rows written before multi-battery
+support are backfilled as `unknown`.
+
+## Development
+
+```sh
+docker compose up --build
+```
+
+Brings up the inserter alongside TimescaleDB, Grafana, Prometheus, Tempo and
+pgAdmin. The container needs `/var/run/dbus` and `privileged: true` to reach the
+host's Bluetooth adapter.

--- a/cmd/litime-timescaledb-inserter/main.go
+++ b/cmd/litime-timescaledb-inserter/main.go
@@ -9,10 +9,9 @@ import (
 	"syscall"
 	"time"
 
-	golitimebluetooth "alpineworks.io/go-litime-bluetooth"
-	"alpineworks.io/go-litime-bluetooth/bluetooth"
 	"alpineworks.io/ootel"
 	"github.com/michaelpeterswa/litime-timescaledb-inserter/internal/config"
+	"github.com/michaelpeterswa/litime-timescaledb-inserter/internal/litime"
 	"github.com/michaelpeterswa/litime-timescaledb-inserter/internal/logging"
 	"github.com/michaelpeterswa/litime-timescaledb-inserter/internal/timescale"
 	"go.opentelemetry.io/contrib/instrumentation/host"
@@ -39,7 +38,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	ctx := context.Background()
+	// Cancelled on SIGINT/SIGTERM, which unwinds the battery supervisors and
+	// closes the reading queue so the writer below can drain and exit.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
 
 	exporterType := ootel.ExporterTypePrometheus
 	if c.Local {
@@ -83,8 +85,23 @@ func main() {
 	}
 
 	defer func() {
-		_ = shutdown(ctx)
+		_ = shutdown(context.Background())
 	}()
+
+	batteries, err := litime.ParseBatteries(c.LitimeBatteries, c.LitimeBatteryBluetoothName)
+	if err != nil {
+		slog.Error("could not determine batteries to poll", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+
+	for _, battery := range batteries {
+		// Log how each battery will be located: a mistyped address falls back to
+		// a name lookup, and this is where that becomes visible.
+		slog.Info("battery configured",
+			slog.String("battery_id", battery.ID),
+			slog.String("match", string(battery.Match)),
+			slog.String("value", battery.Value))
+	}
 
 	timescaleClient, err := timescale.NewTimescaleClient(ctx, c.TimescaleConnString)
 	if err != nil {
@@ -93,62 +110,69 @@ func main() {
 	}
 	defer timescaleClient.Close()
 
-	liTimeClient := bluetooth.NewLiTimeBluetoothClient(c.LitimeBatteryBluetoothName, bluetooth.WithLogger(slog.Default()),
-		bluetooth.WithEnableNotificationCallback(func(b []byte) {
-			callbackCtx, cancel := context.WithTimeout(ctx, c.CallbackTimeout)
-			defer cancel()
-
-			data, err := golitimebluetooth.ParseLiTimeBatteryData(b)
-			if err != nil {
-				slog.Error("failed to parse notification data", slog.String("error", err.Error()))
-				return
-			}
-			slog.Info("received notification data", slog.Any("data", data))
-
-			err = timescaleClient.Insert(callbackCtx, data)
-			if err != nil {
-				slog.Error("failed to insert data into timescale", slog.String("error", err.Error()))
-				return
-			}
-		}),
-	)
-
-	// Connect to the LiTime battery
-	err = liTimeClient.Connect(ctx)
+	metrics, err := litime.NewMetrics()
 	if err != nil {
-		slog.Error("could not connect to litime battery", slog.String("error", err.Error()))
+		slog.Error("could not create metrics", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
 
-	// Start periodic data collection goroutine
-	go func() {
-		ticker := time.NewTicker(c.ScrapeInterval)
-		defer ticker.Stop()
+	manager, err := litime.NewManager(litime.ManagerOptions{
+		Batteries:      batteries,
+		ScrapeInterval: c.ScrapeInterval,
+		ScanTimeout:    c.ScanTimeout,
+		StaleTimeout:   c.StaleTimeout,
+		BufferSize:     c.ReadingBufferSize,
+		Logger:         slog.Default(),
+		Metrics:        metrics,
+	})
+	if err != nil {
+		slog.Error("could not create battery manager", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
 
-		for {
-			select {
-			case <-ctx.Done():
-				slog.Info("stopping periodic data collection")
-				return
-			case <-ticker.C:
-				err := liTimeClient.QueryData()
-				if err != nil {
-					slog.Error("failed to query battery data", slog.String("error", err.Error()))
-					continue
-				}
-			}
-		}
+	managerDone := make(chan error, 1)
+	go func() {
+		managerDone <- manager.Run(ctx)
 	}()
 
 	slog.Info("litime timescaledb inserter started",
 		slog.String("scrape_interval", c.ScrapeInterval.String()),
-		slog.String("battery_name", c.LitimeBatteryBluetoothName))
+		slog.String("stale_timeout", c.StaleTimeout.String()),
+		slog.Int("batteries", len(batteries)))
 
-	// Set up signal handling for graceful shutdown
-	sigChan := make(chan os.Signal, 1)
-	signal.Notify(sigChan, syscall.SIGINT, syscall.SIGTERM)
+	// Writing happens here rather than in the Bluetooth callbacks so that a slow
+	// database cannot stall notification dispatch. The loop ends when the
+	// manager closes the queue, after draining whatever is still in it.
+	for reading := range manager.Readings() {
+		insert(ctx, timescaleClient, metrics, c.CallbackTimeout, reading)
+	}
 
-	// Wait for signal
-	sig := <-sigChan
-	slog.Info("received signal, shutting down gracefully", slog.String("signal", sig.String()))
+	if err := <-managerDone; err != nil {
+		slog.Error("battery manager stopped with an error", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+
+	slog.Info("shutdown complete")
+}
+
+// insert writes one reading, using a background context so that readings still
+// in the queue at shutdown are not abandoned mid-write.
+func insert(ctx context.Context, client *timescale.TimescaleClient, metrics *litime.Metrics, timeout time.Duration, reading litime.Reading) {
+	insertCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+	defer cancel()
+
+	err := client.Insert(insertCtx, reading.BatteryID, reading.ObservedAt, reading.Data)
+	metrics.RecordInsert(insertCtx, reading.BatteryID, err)
+
+	if err != nil {
+		slog.Error("failed to insert data into timescale",
+			slog.String("battery_id", reading.BatteryID),
+			slog.String("error", err.Error()))
+		return
+	}
+
+	slog.Debug("inserted reading",
+		slog.String("battery_id", reading.BatteryID),
+		slog.Int("soc", int(reading.Data.SOC)),
+		slog.Float64("total_voltage", float64(reading.Data.TotalVoltage)))
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,7 +13,12 @@ services:
     privileged: true
     environment:
       TIMESCALE_CONN_STRING: "postgres://postgres:example@timescaledb:5432/postgres?sslmode=disable"
-      LITIME_BATTERY_BLUETOOTH_NAME: "LiTime Battery"
+
+      # Map your own battery IDs to device addresses. The ID is what gets stored
+      # with every reading, so pick something meaningful and stable.
+      # Run `go run ./example/multi` from go-litime-bluetooth to list addresses.
+      # A value that is not an address is treated as an advertised name instead.
+      LITIME_BATTERIES: "garage=11:22:33:AA:BB:CC,shed=11:22:33:AA:BB:CD"
 
       OTEL_EXPORTER_OTLP_ENDPOINT: "http://tempo:4317"
 

--- a/docker/timescale/migrations/004_add_litime_battery_id.down.sql
+++ b/docker/timescale/migrations/004_add_litime_battery_id.down.sql
@@ -1,0 +1,4 @@
+DROP INDEX IF EXISTS sensors.litime_battery_id_time_idx;
+
+ALTER TABLE sensors.litime
+DROP COLUMN IF EXISTS battery_id;

--- a/docker/timescale/migrations/004_add_litime_battery_id.up.sql
+++ b/docker/timescale/migrations/004_add_litime_battery_id.up.sql
@@ -1,0 +1,16 @@
+-- Identify which battery a measurement came from. Without this, readings from
+-- several batteries are indistinguishable once they are in the table.
+--
+-- Existing rows predate multi-battery support and so came from a single unnamed
+-- battery; they are backfilled as 'unknown' rather than guessed at. The default
+-- is dropped afterwards so a future insert that forgets the column fails loudly
+-- instead of quietly landing in the 'unknown' bucket.
+ALTER TABLE sensors.litime
+ADD COLUMN IF NOT EXISTS battery_id TEXT NOT NULL DEFAULT 'unknown';
+
+ALTER TABLE sensors.litime
+ALTER COLUMN battery_id
+DROP DEFAULT;
+
+-- Almost every query is "this battery, recent first".
+CREATE INDEX IF NOT EXISTS litime_battery_id_time_idx ON sensors.litime (battery_id, time DESC);

--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,9 @@ require (
 	github.com/jackc/pgx/v5 v5.7.5
 	go.opentelemetry.io/contrib/instrumentation/host v0.59.0
 	go.opentelemetry.io/contrib/instrumentation/runtime v0.59.0
+	go.opentelemetry.io/otel v1.34.0
+	go.opentelemetry.io/otel/metric v1.34.0
+	tinygo.org/x/bluetooth v0.12.0
 )
 
 require (
@@ -47,13 +50,11 @@ require (
 	github.com/tklauser/numcpus v0.9.0 // indirect
 	github.com/yusufpapurcu/wmi v1.2.4 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
-	go.opentelemetry.io/otel v1.34.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc v1.34.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp v1.34.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.34.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc v1.34.0 // indirect
 	go.opentelemetry.io/otel/exporters/prometheus v0.56.0 // indirect
-	go.opentelemetry.io/otel/metric v1.34.0 // indirect
 	go.opentelemetry.io/otel/sdk v1.34.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.34.0 // indirect
 	go.opentelemetry.io/otel/trace v1.34.0 // indirect
@@ -69,5 +70,6 @@ require (
 	google.golang.org/genproto/googleapis/rpc v0.0.0-20250124145028-65684f501c47 // indirect
 	google.golang.org/grpc v1.70.0 // indirect
 	google.golang.org/protobuf v1.36.4 // indirect
-	tinygo.org/x/bluetooth v0.12.0 // indirect
 )
+
+replace alpineworks.io/go-litime-bluetooth => /Users/michaelpeters/go/src/github.com/alpineworks/go-litime-bluetooth

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 toolchain go1.24.2
 
 require (
-	alpineworks.io/go-litime-bluetooth v1.0.0
+	alpineworks.io/go-litime-bluetooth v1.1.0
 	alpineworks.io/ootel v1.0.4
 	github.com/caarlos0/env/v11 v11.3.1
 	github.com/exaring/otelpgx v0.9.3
@@ -71,5 +71,3 @@ require (
 	google.golang.org/grpc v1.70.0 // indirect
 	google.golang.org/protobuf v1.36.4 // indirect
 )
-
-replace alpineworks.io/go-litime-bluetooth => /Users/michaelpeters/go/src/github.com/alpineworks/go-litime-bluetooth

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+alpineworks.io/go-litime-bluetooth v1.1.0 h1:X5P5dH6b9O1BHHNlUQ8iM7vm0rsXVo8x1DyUOxv2XAc=
+alpineworks.io/go-litime-bluetooth v1.1.0/go.mod h1:hmAPqfWiWDfnHssR8XurZl6kX3RdAAo6iMCnr63YytE=
 alpineworks.io/ootel v1.0.4 h1:NZrYyFsk8obdfhbs0g1+XPXotLdrLO+iJfFRQvfkdfM=
 alpineworks.io/ootel v1.0.4/go.mod h1:ZCKCBy2Q0wVPO03iSSTfbv+GcL/5lU0d+SPH8hTwd3k=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-alpineworks.io/go-litime-bluetooth v1.0.0 h1:8PWpe6NeycVkzBBEiresHAk4zXYZBpOQgYloYr64JPM=
-alpineworks.io/go-litime-bluetooth v1.0.0/go.mod h1:gJALRrB8ARKWzxUSZ/H8wVOT4oLwo3wm+FandDi7P1A=
 alpineworks.io/ootel v1.0.4 h1:NZrYyFsk8obdfhbs0g1+XPXotLdrLO+iJfFRQvfkdfM=
 alpineworks.io/ootel v1.0.4/go.mod h1:ZCKCBy2Q0wVPO03iSSTfbv+GcL/5lU0d+SPH8hTwd3k=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -10,10 +10,35 @@ import (
 type Config struct {
 	LogLevel string `env:"LOG_LEVEL" envDefault:"error"`
 
-	LitimeBatteryBluetoothName string        `env:"LITIME_BATTERY_BLUETOOTH_NAME,required"`
-	TimescaleConnString        string        `env:"TIMESCALE_CONN_STRING,required"`
-	ScrapeInterval             time.Duration `env:"SCRAPE_INTERVAL" envDefault:"10s"`
-	CallbackTimeout            time.Duration `env:"CALLBACK_TIMEOUT" envDefault:"5s"`
+	// LitimeBatteries maps an operator-chosen battery ID to either a Bluetooth
+	// device address or an advertised local name, for example:
+	//
+	//	LITIME_BATTERIES="garage=11:22:33:AA:BB:CC,shed=11:22:33:AA:BB:CD"
+	//
+	// The key/value separator is "=" rather than the library default of ":",
+	// because MAC addresses are full of colons.
+	LitimeBatteries map[string]string `env:"LITIME_BATTERIES" envKeyValSeparator:"="`
+
+	// LitimeBatteryBluetoothName configures a single battery by name. It
+	// predates LITIME_BATTERIES and is used only when that is unset.
+	LitimeBatteryBluetoothName string `env:"LITIME_BATTERY_BLUETOOTH_NAME"`
+
+	TimescaleConnString string        `env:"TIMESCALE_CONN_STRING,required"`
+	ScrapeInterval      time.Duration `env:"SCRAPE_INTERVAL" envDefault:"10s"`
+	CallbackTimeout     time.Duration `env:"CALLBACK_TIMEOUT" envDefault:"5s"`
+	ScanTimeout         time.Duration `env:"SCAN_TIMEOUT" envDefault:"30s"`
+
+	// StaleTimeout is how long a battery may go without returning a reading
+	// before it is treated as gone and reconnected. As a central there is no
+	// notification when a peer disappears, so silence is the only liveness
+	// signal available. Keep it comfortably above SCRAPE_INTERVAL so an
+	// occasional missed reply does not force a reconnect.
+	StaleTimeout time.Duration `env:"STALE_TIMEOUT" envDefault:"90s"`
+
+	// ReadingBufferSize bounds the queue between the Bluetooth callbacks and
+	// the database writer. Readings are dropped rather than queued without
+	// limit if the database cannot keep up.
+	ReadingBufferSize int `env:"READING_BUFFER_SIZE" envDefault:"256"`
 
 	MetricsEnabled bool `env:"METRICS_ENABLED" envDefault:"true"`
 	MetricsPort    int  `env:"METRICS_PORT" envDefault:"8081"`

--- a/internal/litime/battery.go
+++ b/internal/litime/battery.go
@@ -1,0 +1,89 @@
+package litime
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"alpineworks.io/go-litime-bluetooth/bluetooth"
+)
+
+// MatchKind is how a battery is located over Bluetooth.
+type MatchKind string
+
+const (
+	// MatchAddress locates a battery by its BLE device address. This is exact
+	// and is the only reliable option when batteries share an advertised name.
+	MatchAddress MatchKind = "address"
+
+	// MatchName locates a battery by its advertised BLE local name. It only
+	// works when the name is unique among the batteries in range.
+	MatchName MatchKind = "name"
+)
+
+// Battery is one configured battery to poll.
+type Battery struct {
+	// ID is the stable identifier recorded alongside every measurement. It is
+	// operator-chosen, so renaming or replacing hardware does not rewrite
+	// history under a different key.
+	ID string
+
+	// Match is how Value is interpreted.
+	Match MatchKind
+
+	// Value is a device address or an advertised local name, per Match.
+	Value string
+}
+
+// ParseBatteries builds the battery list from configuration.
+//
+// entries maps an operator-chosen ID to either a device address or an advertised
+// local name; which one is decided by whether the value parses as an address for
+// this platform. Callers should log the resulting Match so a mistyped address
+// falling back to a name lookup is visible rather than silent.
+//
+// fallbackName preserves the older single-battery configuration and is used only
+// when entries is empty.
+func ParseBatteries(entries map[string]string, fallbackName string) ([]Battery, error) {
+	if len(entries) == 0 {
+		if fallbackName == "" {
+			return nil, fmt.Errorf("no batteries configured")
+		}
+
+		return []Battery{{ID: fallbackName, Match: MatchName, Value: fallbackName}}, nil
+	}
+
+	batteries := make([]Battery, 0, len(entries))
+	seen := make(map[string]string, len(entries))
+
+	for id, value := range entries {
+		id = strings.TrimSpace(id)
+		value = strings.TrimSpace(value)
+
+		if id == "" {
+			return nil, fmt.Errorf("battery id must not be empty")
+		}
+		if value == "" {
+			return nil, fmt.Errorf("battery %q has no address or name", id)
+		}
+
+		match := MatchName
+		if _, err := bluetooth.ParseAddress(value); err == nil {
+			match = MatchAddress
+		}
+
+		// Two IDs pointing at one battery would double every measurement and
+		// silently halve the apparent poll interval for both.
+		if previous, duplicate := seen[value]; duplicate {
+			return nil, fmt.Errorf("batteries %q and %q both refer to %q", previous, id, value)
+		}
+		seen[value] = id
+
+		batteries = append(batteries, Battery{ID: id, Match: match, Value: value})
+	}
+
+	// Map iteration is randomised, so sort for stable logs and startup order.
+	sort.Slice(batteries, func(i, j int) bool { return batteries[i].ID < batteries[j].ID })
+
+	return batteries, nil
+}

--- a/internal/litime/battery_linux_test.go
+++ b/internal/litime/battery_linux_test.go
@@ -1,0 +1,41 @@
+//go:build linux
+
+package litime
+
+import "testing"
+
+// Device addresses are MAC addresses on Linux, so address-versus-name
+// classification can only be asserted per platform.
+func TestParseBatteriesClassifiesAddresses(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		value string
+		want  MatchKind
+	}{
+		{name: "upper case mac", value: "11:22:33:AA:BB:CC", want: MatchAddress},
+		{name: "lower case mac", value: "11:22:33:aa:bb:cc", want: MatchAddress},
+		{name: "advertised name", value: "LiTime Battery", want: MatchName},
+		{name: "serial style name", value: "L-12100BNNA70-A19081", want: MatchName},
+		// A truncated MAC is far more likely to be a typo than a device name,
+		// but it cannot be told apart from one, so it is treated as a name and
+		// the startup log is what surfaces the mistake.
+		{name: "truncated mac falls back to name", value: "11:22:33:AA:BB", want: MatchName},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			batteries, err := ParseBatteries(map[string]string{"garage": tt.value}, "")
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+
+			if batteries[0].Match != tt.want {
+				t.Errorf("ParseBatteries(%q) matched by %q, want %q", tt.value, batteries[0].Match, tt.want)
+			}
+		})
+	}
+}

--- a/internal/litime/battery_test.go
+++ b/internal/litime/battery_test.go
@@ -1,0 +1,135 @@
+package litime
+
+import "testing"
+
+func TestParseBatteriesFallsBackToSingleName(t *testing.T) {
+	t.Parallel()
+
+	batteries, err := ParseBatteries(nil, "LiTime Battery")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(batteries) != 1 {
+		t.Fatalf("got %d batteries, want 1", len(batteries))
+	}
+
+	want := Battery{ID: "LiTime Battery", Match: MatchName, Value: "LiTime Battery"}
+	if batteries[0] != want {
+		t.Errorf("got %+v, want %+v", batteries[0], want)
+	}
+}
+
+func TestParseBatteriesPrefersExplicitList(t *testing.T) {
+	t.Parallel()
+
+	batteries, err := ParseBatteries(map[string]string{"garage": "battery-one"}, "ignored-fallback")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(batteries) != 1 {
+		t.Fatalf("got %d batteries, want 1", len(batteries))
+	}
+
+	if batteries[0].ID != "garage" || batteries[0].Value != "battery-one" {
+		t.Errorf("got %+v, want the configured list to win over the fallback", batteries[0])
+	}
+}
+
+func TestParseBatteriesSortsByID(t *testing.T) {
+	t.Parallel()
+
+	// Map iteration is randomised, so an unsorted implementation would only fail
+	// this intermittently. Enough entries to make that unlikely to slip through.
+	entries := map[string]string{
+		"shed":    "d",
+		"garage":  "b",
+		"attic":   "a",
+		"cellar":  "c",
+		"kitchen": "e",
+	}
+
+	batteries, err := ParseBatteries(entries, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	want := []string{"attic", "cellar", "garage", "kitchen", "shed"}
+	if len(batteries) != len(want) {
+		t.Fatalf("got %d batteries, want %d", len(batteries), len(want))
+	}
+
+	for i, id := range want {
+		if batteries[i].ID != id {
+			t.Errorf("battery %d is %q, want %q", i, batteries[i].ID, id)
+		}
+	}
+}
+
+func TestParseBatteriesRejectsDuplicateTargets(t *testing.T) {
+	t.Parallel()
+
+	// Two IDs pointing at one battery would write every reading twice.
+	_, err := ParseBatteries(map[string]string{
+		"garage": "same-battery",
+		"shed":   "same-battery",
+	}, "")
+	if err == nil {
+		t.Fatal("expected an error for two batteries sharing a target")
+	}
+}
+
+func TestParseBatteriesTrimsWhitespace(t *testing.T) {
+	t.Parallel()
+
+	batteries, err := ParseBatteries(map[string]string{"  garage  ": "  battery-one  "}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if batteries[0].ID != "garage" || batteries[0].Value != "battery-one" {
+		t.Errorf("got %+v, want whitespace trimmed", batteries[0])
+	}
+}
+
+func TestParseBatteriesRejectsBadInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name     string
+		entries  map[string]string
+		fallback string
+	}{
+		{name: "nothing configured at all", entries: nil, fallback: ""},
+		{name: "empty id", entries: map[string]string{"": "battery-one"}, fallback: ""},
+		{name: "whitespace only id", entries: map[string]string{"   ": "battery-one"}, fallback: ""},
+		{name: "empty value", entries: map[string]string{"garage": ""}, fallback: ""},
+		{name: "whitespace only value", entries: map[string]string{"garage": "   "}, fallback: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := ParseBatteries(tt.entries, tt.fallback); err == nil {
+				t.Error("expected an error, got nil")
+			}
+		})
+	}
+}
+
+// A value that is not a device address must be treated as an advertised name on
+// every platform, since that is the only other thing it can be.
+func TestParseBatteriesClassifiesNonAddressAsName(t *testing.T) {
+	t.Parallel()
+
+	batteries, err := ParseBatteries(map[string]string{"garage": "L-12100BNNA70-A19081"}, "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if batteries[0].Match != MatchName {
+		t.Errorf("got match %q, want %q", batteries[0].Match, MatchName)
+	}
+}

--- a/internal/litime/manager.go
+++ b/internal/litime/manager.go
@@ -1,0 +1,421 @@
+package litime
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	golitimebluetooth "alpineworks.io/go-litime-bluetooth"
+	"alpineworks.io/go-litime-bluetooth/bluetooth"
+	tinygobluetooth "tinygo.org/x/bluetooth"
+)
+
+const (
+	minReconnectBackoff = 5 * time.Second
+	maxReconnectBackoff = 5 * time.Minute
+)
+
+// Reading is one measurement together with the battery that produced it.
+type Reading struct {
+	BatteryID  string
+	ObservedAt time.Time
+	Data       *golitimebluetooth.LiTimeBatteryData
+}
+
+// ManagerOptions configures a Manager.
+type ManagerOptions struct {
+	Batteries      []Battery
+	ScrapeInterval time.Duration
+	ScanTimeout    time.Duration
+
+	// StaleTimeout is how long a battery may stay silent before it is treated
+	// as disconnected and cycled.
+	StaleTimeout time.Duration
+
+	// BufferSize bounds the reading queue handed to the consumer.
+	BufferSize int
+
+	Logger  *slog.Logger
+	Metrics *Metrics
+}
+
+// Manager keeps a connection to every configured battery and publishes their
+// readings on a single channel.
+//
+// One Manager owns all the batteries deliberately. They share a radio, and the
+// Bluetooth stack allows only one scan at a time, so resolving addresses has to
+// happen centrally rather than per battery.
+type Manager struct {
+	batteries      []Battery
+	scrapeInterval time.Duration
+	scanTimeout    time.Duration
+	staleTimeout   time.Duration
+	logger         *slog.Logger
+	metrics        *Metrics
+
+	readings chan Reading
+	// closeMu guards closing readings against concurrent publishes. The
+	// Bluetooth stack's notification goroutine outlives Disconnect, so without
+	// this a notification arriving during shutdown would send on a closed
+	// channel and panic.
+	closeMu sync.RWMutex
+	closed  bool
+}
+
+// publishResult reports what became of a reading offered to the queue.
+type publishResult int
+
+const (
+	published publishResult = iota
+	droppedQueueFull
+	droppedShuttingDown
+)
+
+func NewManager(opts ManagerOptions) (*Manager, error) {
+	if len(opts.Batteries) == 0 {
+		return nil, fmt.Errorf("no batteries configured")
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+	if opts.BufferSize <= 0 {
+		opts.BufferSize = 256
+	}
+	if opts.StaleTimeout <= 0 {
+		opts.StaleTimeout = 90 * time.Second
+	}
+	if opts.ScrapeInterval <= 0 {
+		opts.ScrapeInterval = 10 * time.Second
+	}
+	if opts.StaleTimeout <= opts.ScrapeInterval {
+		return nil, fmt.Errorf("stale timeout (%s) must exceed scrape interval (%s)", opts.StaleTimeout, opts.ScrapeInterval)
+	}
+
+	return &Manager{
+		batteries:      opts.Batteries,
+		scrapeInterval: opts.ScrapeInterval,
+		scanTimeout:    opts.ScanTimeout,
+		staleTimeout:   opts.StaleTimeout,
+		logger:         opts.Logger,
+		metrics:        opts.Metrics,
+		readings:       make(chan Reading, opts.BufferSize),
+	}, nil
+}
+
+// Readings returns the channel every battery publishes to. It is closed once Run
+// has returned and no further readings will arrive.
+func (m *Manager) Readings() <-chan Reading {
+	return m.readings
+}
+
+// Run supervises every battery until ctx is cancelled.
+//
+// Batteries that cannot be reached do not prevent the others from running: each
+// is supervised independently and retried with backoff, so one flat or
+// out-of-range battery never stalls the rest.
+func (m *Manager) Run(ctx context.Context) error {
+	defer m.closeReadings()
+
+	resolved, err := m.resolveAddresses(ctx)
+	if err != nil {
+		return err
+	}
+
+	var wg sync.WaitGroup
+	for _, battery := range m.batteries {
+		address, ok := resolved[battery.ID]
+		if !ok {
+			// Only name-matched batteries can be missing here, and a battery
+			// absent at startup may well appear later, so keep supervising it.
+			m.logger.Warn("battery not found during scan, will keep retrying",
+				slog.String("battery_id", battery.ID),
+				slog.String("name", battery.Value))
+		}
+
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			m.superviseBattery(ctx, battery, address, ok)
+		}()
+	}
+
+	wg.Wait()
+
+	return nil
+}
+
+// resolveAddresses turns the configured batteries into device addresses.
+//
+// Everything matched by name is resolved in a single scan. Scanning per battery
+// is not an option: the adapter runs one scan at a time, so concurrent scans
+// fail and sequential ones pay the timeout once per battery.
+func (m *Manager) resolveAddresses(ctx context.Context) (map[string]tinygobluetooth.Address, error) {
+	resolved := make(map[string]tinygobluetooth.Address, len(m.batteries))
+
+	var names []string
+	byName := make(map[string][]string)
+
+	for _, battery := range m.batteries {
+		if battery.Match == MatchAddress {
+			address, err := bluetooth.ParseAddress(battery.Value)
+			if err != nil {
+				return nil, fmt.Errorf("battery %q: %w", battery.ID, err)
+			}
+			resolved[battery.ID] = address
+			continue
+		}
+
+		if _, seen := byName[battery.Value]; !seen {
+			names = append(names, battery.Value)
+		}
+		byName[battery.Value] = append(byName[battery.Value], battery.ID)
+	}
+
+	if len(names) == 0 {
+		return resolved, nil
+	}
+
+	m.logger.Info("scanning for batteries by name", slog.Any("names", names))
+
+	devices, err := bluetooth.ScanForDevices(ctx,
+		bluetooth.ScanWithLogger(m.logger),
+		bluetooth.ScanWithTimeout(m.scanTimeout),
+		bluetooth.ScanWithNames(names...),
+		bluetooth.ScanWithTargetCount(len(names)),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("failed to scan for batteries: %w", err)
+	}
+
+	found := make(map[string][]tinygobluetooth.Address)
+	for _, device := range devices {
+		found[device.Name] = append(found[device.Name], device.Address)
+	}
+
+	for name, ids := range byName {
+		matches := found[name]
+
+		// Several batteries answering to one name cannot be told apart, and
+		// picking arbitrarily would attribute readings to the wrong battery.
+		if len(matches) > 1 {
+			return nil, fmt.Errorf(
+				"%d devices advertise the name %q; configure these batteries by address instead: %v",
+				len(matches), name, addressStrings(matches))
+		}
+
+		if len(matches) == 0 {
+			continue
+		}
+
+		for _, id := range ids {
+			resolved[id] = matches[0]
+		}
+	}
+
+	return resolved, nil
+}
+
+func addressStrings(addresses []tinygobluetooth.Address) []string {
+	out := make([]string, 0, len(addresses))
+	for _, address := range addresses {
+		out = append(out, address.String())
+	}
+
+	return out
+}
+
+// superviseBattery keeps one battery connected and polled for the lifetime of
+// ctx, reconnecting whenever it falls silent.
+func (m *Manager) superviseBattery(ctx context.Context, battery Battery, address tinygobluetooth.Address, haveAddress bool) {
+	logger := m.logger.With(slog.String("battery_id", battery.ID))
+	backoff := minReconnectBackoff
+
+	for ctx.Err() == nil {
+		if !haveAddress {
+			// The battery was not in range at startup. Rescanning is cheap
+			// relative to the retry interval and is the only way it can appear.
+			found, err := m.resolveAddresses(ctx)
+			if err != nil {
+				logger.Error("failed to scan for battery", slog.String("error", err.Error()))
+			} else if a, ok := found[battery.ID]; ok {
+				address, haveAddress = a, true
+			}
+
+			if !haveAddress {
+				if !sleep(ctx, backoff) {
+					return
+				}
+				backoff = nextBackoff(backoff)
+				continue
+			}
+		}
+
+		client, lastSeen, err := m.connect(ctx, battery, address, logger)
+		if err != nil {
+			logger.Error("failed to connect to battery",
+				slog.String("address", address.String()),
+				slog.String("error", err.Error()))
+			m.metrics.recordConnected(ctx, battery.ID, false)
+
+			if !sleep(ctx, backoff) {
+				return
+			}
+			backoff = nextBackoff(backoff)
+			continue
+		}
+
+		logger.Info("connected to battery", slog.String("address", address.String()))
+		m.metrics.recordConnected(ctx, battery.ID, true)
+		backoff = minReconnectBackoff
+
+		reason := m.pollUntilStale(ctx, client, lastSeen)
+
+		if err := client.Disconnect(); err != nil {
+			logger.Warn("failed to disconnect cleanly", slog.String("error", err.Error()))
+		}
+		m.metrics.recordConnected(ctx, battery.ID, false)
+
+		if ctx.Err() != nil {
+			return
+		}
+
+		logger.Warn("battery connection lost, reconnecting", slog.String("reason", reason))
+		m.metrics.recordReconnect(ctx, battery.ID)
+
+		if !sleep(ctx, backoff) {
+			return
+		}
+		backoff = nextBackoff(backoff)
+	}
+}
+
+// connect builds a client for one battery and establishes its connection. The
+// returned counter carries the time of that connection's most recent reading.
+func (m *Manager) connect(ctx context.Context, battery Battery, address tinygobluetooth.Address, logger *slog.Logger) (*bluetooth.LiTimeBluetoothClient, *atomic.Int64, error) {
+	// lastSeen belongs to this connection attempt alone, so a reading from a
+	// previous connection cannot make a fresh one look alive.
+	lastSeen := &atomic.Int64{}
+	lastSeen.Store(time.Now().UnixNano())
+
+	client := bluetooth.NewLiTimeBluetoothClient(battery.Value,
+		bluetooth.WithAddress(address),
+		bluetooth.WithLogger(logger),
+		bluetooth.WithScanTimeout(m.scanTimeout),
+		bluetooth.WithEnableNotificationCallback(func(b []byte) {
+			m.handleNotification(ctx, battery, b, lastSeen, logger)
+		}),
+	)
+
+	if err := client.Connect(ctx); err != nil {
+		return nil, nil, err
+	}
+
+	return client, lastSeen, nil
+}
+
+// handleNotification parses an incoming notification and queues it.
+//
+// This runs on the Bluetooth stack's dispatch goroutine, so it must not block:
+// the queue is therefore offered a reading and the reading is dropped if the
+// consumer has fallen behind.
+func (m *Manager) handleNotification(ctx context.Context, battery Battery, b []byte, lastSeen *atomic.Int64, logger *slog.Logger) {
+	data, err := golitimebluetooth.ParseLiTimeBatteryData(b)
+	if err != nil {
+		logger.Error("failed to parse notification data", slog.String("error", err.Error()))
+		m.metrics.recordParseFailure(ctx, battery.ID)
+		return
+	}
+
+	lastSeen.Store(time.Now().UnixNano())
+	m.metrics.recordNotification(ctx, battery.ID)
+
+	switch m.publish(Reading{
+		BatteryID:  battery.ID,
+		ObservedAt: time.Now(),
+		Data:       data,
+	}) {
+	case droppedQueueFull:
+		logger.Warn("reading queue full, dropping reading")
+		m.metrics.recordDropped(ctx, battery.ID)
+	case droppedShuttingDown:
+		logger.Debug("dropping reading received during shutdown")
+	case published:
+	}
+}
+
+// publish offers a reading to the queue without ever blocking, because it runs
+// on the Bluetooth stack's dispatch goroutine.
+func (m *Manager) publish(reading Reading) publishResult {
+	m.closeMu.RLock()
+	defer m.closeMu.RUnlock()
+
+	if m.closed {
+		return droppedShuttingDown
+	}
+
+	select {
+	case m.readings <- reading:
+		return published
+	default:
+		return droppedQueueFull
+	}
+}
+
+// closeReadings ends the stream, waiting out any publish already in flight.
+func (m *Manager) closeReadings() {
+	m.closeMu.Lock()
+	defer m.closeMu.Unlock()
+
+	m.closed = true
+	close(m.readings)
+}
+
+// pollUntilStale queries the battery on an interval and returns once it stops
+// answering or ctx is cancelled, reporting why.
+func (m *Manager) pollUntilStale(ctx context.Context, client *bluetooth.LiTimeBluetoothClient, lastSeen *atomic.Int64) string {
+	ticker := time.NewTicker(m.scrapeInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return "shutting down"
+		case <-ticker.C:
+			if err := client.QueryData(); err != nil {
+				return fmt.Sprintf("query failed: %s", err)
+			}
+
+			// A central gets no notification when a peer disappears, so silence
+			// is the only signal that the battery is gone.
+			silence := time.Since(time.Unix(0, lastSeen.Load()))
+			if silence > m.staleTimeout {
+				return fmt.Sprintf("no reading for %s", silence.Round(time.Second))
+			}
+		}
+	}
+}
+
+// sleep waits for d, reporting false if ctx was cancelled first.
+func sleep(ctx context.Context, d time.Duration) bool {
+	timer := time.NewTimer(d)
+	defer timer.Stop()
+
+	select {
+	case <-ctx.Done():
+		return false
+	case <-timer.C:
+		return true
+	}
+}
+
+func nextBackoff(current time.Duration) time.Duration {
+	next := current * 2
+	if next > maxReconnectBackoff {
+		return maxReconnectBackoff
+	}
+
+	return next
+}

--- a/internal/litime/manager_test.go
+++ b/internal/litime/manager_test.go
@@ -1,0 +1,116 @@
+package litime
+
+import (
+	"sync"
+	"testing"
+	"time"
+)
+
+func testManager(t *testing.T, bufferSize int) *Manager {
+	t.Helper()
+
+	m, err := NewManager(ManagerOptions{
+		Batteries:      []Battery{{ID: "garage", Match: MatchName, Value: "battery"}},
+		ScrapeInterval: time.Second,
+		StaleTimeout:   10 * time.Second,
+		BufferSize:     bufferSize,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	return m
+}
+
+func TestNewManagerRejectsStaleTimeoutBelowScrapeInterval(t *testing.T) {
+	t.Parallel()
+
+	// A stale timeout under the scrape interval would declare every battery
+	// dead before it had a chance to answer, reconnecting in a tight loop.
+	_, err := NewManager(ManagerOptions{
+		Batteries:      []Battery{{ID: "garage", Match: MatchName, Value: "battery"}},
+		ScrapeInterval: 30 * time.Second,
+		StaleTimeout:   10 * time.Second,
+	})
+	if err == nil {
+		t.Fatal("expected an error when stale timeout is below the scrape interval")
+	}
+}
+
+func TestNewManagerRequiresBatteries(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewManager(ManagerOptions{}); err == nil {
+		t.Fatal("expected an error when no batteries are configured")
+	}
+}
+
+func TestPublishDropsWhenQueueFull(t *testing.T) {
+	t.Parallel()
+
+	m := testManager(t, 1)
+
+	if got := m.publish(Reading{BatteryID: "garage"}); got != published {
+		t.Fatalf("first publish = %v, want published", got)
+	}
+
+	// Nothing is draining, so the queue is now full. Dropping is required
+	// rather than blocking: publish runs on the Bluetooth dispatch goroutine.
+	if got := m.publish(Reading{BatteryID: "garage"}); got != droppedQueueFull {
+		t.Errorf("second publish = %v, want droppedQueueFull", got)
+	}
+}
+
+func TestPublishAfterCloseDoesNotPanic(t *testing.T) {
+	t.Parallel()
+
+	m := testManager(t, 4)
+	m.closeReadings()
+
+	// The Bluetooth stack's notification goroutine outlives Disconnect, so a
+	// reading can arrive after the stream has been closed. Sending it to the
+	// closed channel would panic and take the process down at shutdown.
+	if got := m.publish(Reading{BatteryID: "garage"}); got != droppedShuttingDown {
+		t.Errorf("publish after close = %v, want droppedShuttingDown", got)
+	}
+}
+
+// TestPublishRacesWithClose is meaningful under -race: it drives concurrent
+// publishes against a close, which is exactly the shutdown ordering that a
+// late-arriving notification produces.
+func TestPublishRacesWithClose(t *testing.T) {
+	t.Parallel()
+
+	for range 50 {
+		m := testManager(t, 8)
+
+		var wg sync.WaitGroup
+		start := make(chan struct{})
+
+		for range 4 {
+			wg.Add(1)
+			go func() {
+				defer wg.Done()
+				<-start
+				for range 25 {
+					m.publish(Reading{BatteryID: "garage"})
+				}
+			}()
+		}
+
+		// Drain so the queue does not simply fill and make every publish a
+		// no-op that never reaches the channel send.
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for range m.Readings() {
+			}
+		}()
+
+		close(start)
+		time.Sleep(time.Millisecond)
+		m.closeReadings()
+
+		wg.Wait()
+	}
+}

--- a/internal/litime/metrics.go
+++ b/internal/litime/metrics.go
@@ -1,0 +1,148 @@
+package litime
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const meterName = "github.com/michaelpeterswa/litime-timescaledb-inserter"
+
+// Metrics reports per-battery health.
+//
+// Everything here is labelled by battery, because with several batteries the
+// operational question stops being "is it running" and becomes "is one of them
+// quietly dead". Aggregate counters cannot answer that.
+type Metrics struct {
+	connected     metric.Int64Gauge
+	notifications metric.Int64Counter
+	reconnects    metric.Int64Counter
+	dropped       metric.Int64Counter
+	parseFailures metric.Int64Counter
+	inserts       metric.Int64Counter
+	insertErrors  metric.Int64Counter
+}
+
+func NewMetrics() (*Metrics, error) {
+	meter := otel.Meter(meterName)
+
+	connected, err := meter.Int64Gauge("litime.battery.connected",
+		metric.WithDescription("Whether a battery is currently connected (1) or not (0)"))
+	if err != nil {
+		return nil, err
+	}
+
+	notifications, err := meter.Int64Counter("litime.battery.notifications",
+		metric.WithDescription("Readings received from a battery"))
+	if err != nil {
+		return nil, err
+	}
+
+	reconnects, err := meter.Int64Counter("litime.battery.reconnects",
+		metric.WithDescription("Times a battery connection was re-established"))
+	if err != nil {
+		return nil, err
+	}
+
+	dropped, err := meter.Int64Counter("litime.battery.readings_dropped",
+		metric.WithDescription("Readings discarded because the write queue was full"))
+	if err != nil {
+		return nil, err
+	}
+
+	parseFailures, err := meter.Int64Counter("litime.battery.parse_failures",
+		metric.WithDescription("Notifications that could not be parsed"))
+	if err != nil {
+		return nil, err
+	}
+
+	inserts, err := meter.Int64Counter("litime.inserts",
+		metric.WithDescription("Readings written to the database"))
+	if err != nil {
+		return nil, err
+	}
+
+	insertErrors, err := meter.Int64Counter("litime.insert_errors",
+		metric.WithDescription("Readings that failed to be written to the database"))
+	if err != nil {
+		return nil, err
+	}
+
+	return &Metrics{
+		connected:     connected,
+		notifications: notifications,
+		reconnects:    reconnects,
+		dropped:       dropped,
+		parseFailures: parseFailures,
+		inserts:       inserts,
+		insertErrors:  insertErrors,
+	}, nil
+}
+
+// The recorders below tolerate a nil receiver so that metrics stay optional and
+// callers are not littered with nil checks.
+
+func battery(id string) metric.MeasurementOption {
+	return metric.WithAttributes(attribute.String("battery_id", id))
+}
+
+func (m *Metrics) recordConnected(ctx context.Context, batteryID string, connected bool) {
+	if m == nil {
+		return
+	}
+
+	var value int64
+	if connected {
+		value = 1
+	}
+
+	m.connected.Record(ctx, value, battery(batteryID))
+}
+
+func (m *Metrics) recordNotification(ctx context.Context, batteryID string) {
+	if m == nil {
+		return
+	}
+
+	m.notifications.Add(ctx, 1, battery(batteryID))
+}
+
+func (m *Metrics) recordReconnect(ctx context.Context, batteryID string) {
+	if m == nil {
+		return
+	}
+
+	m.reconnects.Add(ctx, 1, battery(batteryID))
+}
+
+func (m *Metrics) recordDropped(ctx context.Context, batteryID string) {
+	if m == nil {
+		return
+	}
+
+	m.dropped.Add(ctx, 1, battery(batteryID))
+}
+
+func (m *Metrics) recordParseFailure(ctx context.Context, batteryID string) {
+	if m == nil {
+		return
+	}
+
+	m.parseFailures.Add(ctx, 1, battery(batteryID))
+}
+
+// RecordInsert reports the outcome of writing one reading to the database.
+func (m *Metrics) RecordInsert(ctx context.Context, batteryID string, err error) {
+	if m == nil {
+		return
+	}
+
+	if err != nil {
+		m.insertErrors.Add(ctx, 1, battery(batteryID))
+		return
+	}
+
+	m.inserts.Add(ctx, 1, battery(batteryID))
+}

--- a/internal/timescale/queries/insert_litime.pgsql
+++ b/internal/timescale/queries/insert_litime.pgsql
@@ -1,6 +1,7 @@
 INSERT INTO
     sensors.litime (
         time,
+        battery_id,
         total_voltage,
         cell_voltage_sum,
         current,
@@ -40,5 +41,6 @@ VALUES
         $16,
         $17,
         $18,
-        $19
+        $19,
+        $20
     );

--- a/internal/timescale/timescale.go
+++ b/internal/timescale/timescale.go
@@ -48,9 +48,13 @@ func (c *TimescaleClient) Close() {
 //go:embed queries/insert_litime.pgsql
 var insertLitime string
 
-func (c *TimescaleClient) Insert(ctx context.Context, measure *golitimebluetooth.LiTimeBatteryData) error {
+// Insert records one measurement against the battery it came from. Callers pass
+// the observation time explicitly so a reading is stored with the moment the
+// battery reported it rather than the moment it reached the database.
+func (c *TimescaleClient) Insert(ctx context.Context, batteryID string, observedAt time.Time, measure *golitimebluetooth.LiTimeBatteryData) error {
 	_, err := c.Pool.Exec(ctx, insertLitime,
-		time.Now(),
+		observedAt,
+		batteryID,
 		measure.TotalVoltage,
 		measure.CellVoltageSum,
 		measure.Current,


### PR DESCRIPTION
Replaces the single hardcoded battery with a configured set, each identified by an operator-chosen ID stored with every reading.

Depends on `alpineworks.io/go-litime-bluetooth` v1.1.0 (alpineworks/go-litime-bluetooth#3), now released.

## Configuration

```sh
LITIME_BATTERIES="garage=11:22:33:AA:BB:CC,shed=11:22:33:AA:BB:CD"
```

The key/value separator is `=`, not the library default `:`, because MAC addresses are full of colons. A value is treated as an address if it parses as one and as an advertised name otherwise; which was chosen is logged at startup, so a mistyped address shows up as `"match":"name"` rather than failing mysteriously.

`LITIME_BATTERY_BLUETOOTH_NAME` still works and configures a single battery by name.

## Design, and why

All batteries share one radio, which drives most of this:

- **One scan resolves every battery.** An adapter runs a single scan at a time, so scanning per battery does not work. Batteries configured by address skip scanning entirely. If several devices answer to one configured name, startup fails and reports the addresses to use, rather than attributing readings to whichever the adapter surfaced first.
- **Each battery is supervised independently**, with exponential backoff, so one flat or out-of-range battery never stalls the others. A battery missing at startup keeps being retried.
- **Silence is the liveness signal.** As a central there is no notification when a peer disappears (see the finding in alpineworks/go-litime-bluetooth#3), so a battery producing no reading within `STALE_TIMEOUT` is cycled. `NewManager` rejects a stale timeout below the scrape interval, which would reconnect in a tight loop.
- **Writes moved off the Bluetooth callback.** Readings go through a bounded queue to a dedicated writer, so a slow database cannot stall notification dispatch. A full queue drops and counts readings rather than growing without limit.

## A bug this fixes on the way

The stack's notification goroutine outlives `Disconnect()`, so a late-arriving reading would send on the closed readings channel and panic during shutdown. Closing is now guarded. `TestPublishAfterCloseDoesNotPanic` and a `-race` stress test cover it; removing the guard reproduces `panic: send on closed channel`.

## Schema

Migration 004 adds `sensors.litime.battery_id` with an index on `(battery_id, time DESC)`. Existing rows are backfilled as `unknown`, then the default is dropped so a future insert missing the column fails loudly instead of landing quietly in that bucket.

## Metrics

Per-battery series labelled `battery_id` — connection state, notifications, reconnects, dropped readings, parse failures, insert outcomes. With several batteries the operational question stops being "is it running" and becomes "has one of them quietly died", which aggregate counters cannot answer.

## Testing

- Builds for darwin and linux/arm64; `go vet` and `gofmt` clean
- All tests pass under `-race` on darwin and on real Linux via Docker
- Migration 004 applied to a real TimescaleDB hypertable, including rollback and re-apply; backfill confirmed to produce `unknown`
- The 20-parameter insert exercised with two batteries, and the `NOT NULL` constraint confirmed to reject a missing `battery_id`

**No Bluetooth code path has executed.** No adapter and no batteries were involved, so scanning, connecting, the reconnect watchdog and multi-connection behaviour all need validating on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
