### PR TITLE
fix: depend on go-litime-bluetooth v1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,12 +65,18 @@ a value discovered on one operating system will not work on another.
 
 All batteries share a single Bluetooth radio, which constrains the design:
 
-- **One scan resolves every battery.** An adapter runs only one scan at a time,
-  so scanning per battery would fail outright. Batteries configured by address
-  skip scanning altogether.
-- **Connections are independent.** Each battery is supervised on its own
-  goroutine and retried with exponential backoff, so one flat or out-of-range
-  battery never stalls the others.
+- **Every connection attempt scans first.** BlueZ can only connect to a device it
+  currently holds an object for, and it discards those over time, so a scan is
+  what makes a device connectable — including on reconnect and including when
+  the address is already known. Configuring an address narrows the scan rather
+  than skipping it.
+- **Scanning and connecting are serialised across batteries.** An adapter runs
+  one scan at a time, and a controller establishes one connection at a time.
+  Overlapping attempts abort each other, which shows up as a battery that was
+  working failing when another is added.
+- **Supervision is per battery.** Each is retried on its own goroutine with
+  exponential backoff, so one flat or out-of-range battery never stalls the
+  others.
 - **Silence is the liveness signal.** As a Bluetooth central there is no
   notification when a peer disappears, so a battery that has not produced a
   reading within `STALE_TIMEOUT` is disconnected and reconnected. Keep

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 toolchain go1.24.2
 
 require (
-	alpineworks.io/go-litime-bluetooth v1.1.0
+	alpineworks.io/go-litime-bluetooth v1.1.1
 	alpineworks.io/ootel v1.0.4
 	github.com/caarlos0/env/v11 v11.3.1
 	github.com/exaring/otelpgx v0.9.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-alpineworks.io/go-litime-bluetooth v1.1.0 h1:X5P5dH6b9O1BHHNlUQ8iM7vm0rsXVo8x1DyUOxv2XAc=
-alpineworks.io/go-litime-bluetooth v1.1.0/go.mod h1:hmAPqfWiWDfnHssR8XurZl6kX3RdAAo6iMCnr63YytE=
+alpineworks.io/go-litime-bluetooth v1.1.1 h1:E1vPZQIhvgqTi2N7ZlbU4a0ilGWhR05NcE6fl6gKsMg=
+alpineworks.io/go-litime-bluetooth v1.1.1/go.mod h1:hmAPqfWiWDfnHssR8XurZl6kX3RdAAo6iMCnr63YytE=
 alpineworks.io/ootel v1.0.4 h1:NZrYyFsk8obdfhbs0g1+XPXotLdrLO+iJfFRQvfkdfM=
 alpineworks.io/ootel v1.0.4/go.mod h1:ZCKCBy2Q0wVPO03iSSTfbv+GcL/5lU0d+SPH8hTwd3k=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
Picks up alpineworks/go-litime-bluetooth#4.

v1.1.0 had two defects that made multi-battery use unreliable in exactly the case it was written for:

- Connecting by address skipped the scan, and reconnects reused the address resolved at startup. BlueZ can only connect to a device it currently holds an object for and discards those over time, so a battery reconnected only until its object aged out, then failed with `Method "Get" ... doesn't exist`.
- Connection attempts were allowed to overlap. A controller establishes one LE connection at a time, so two batteries connecting together aborted each other with `le-connection-abort-by-local` — surfacing on the battery that was already working, not the one being added.

v1.1.1 scans before every connect and serialises establishment per adapter. The supervisor's reconnect path needs no change here: it recreates the client per attempt, so it picks up the corrected behaviour directly.

Also corrects the README, which claimed batteries configured by address "skip scanning altogether" — the opposite of what BlueZ requires.

## Testing

Builds for darwin and linux/arm64; `go vet`, `gofmt` and the race tests all clean.

Not hardware-verified. The batteries this was found on stopped accepting connections during diagnosis and had not recovered at time of writing, so the deployment that exercises this is still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)