### PR TITLE
fix: depend on go-litime-bluetooth v1.1.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.24
 toolchain go1.24.2
 
 require (
-	alpineworks.io/go-litime-bluetooth v1.1.1
+	alpineworks.io/go-litime-bluetooth v1.1.2
 	alpineworks.io/ootel v1.0.4
 	github.com/caarlos0/env/v11 v11.3.1
 	github.com/exaring/otelpgx v0.9.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-alpineworks.io/go-litime-bluetooth v1.1.1 h1:E1vPZQIhvgqTi2N7ZlbU4a0ilGWhR05NcE6fl6gKsMg=
-alpineworks.io/go-litime-bluetooth v1.1.1/go.mod h1:hmAPqfWiWDfnHssR8XurZl6kX3RdAAo6iMCnr63YytE=
+alpineworks.io/go-litime-bluetooth v1.1.2 h1:48knAE0PhaHFqzf+mCav49bMti5PZLkpl1n1qkGIKhQ=
+alpineworks.io/go-litime-bluetooth v1.1.2/go.mod h1:hmAPqfWiWDfnHssR8XurZl6kX3RdAAo6iMCnr63YytE=
 alpineworks.io/ootel v1.0.4 h1:NZrYyFsk8obdfhbs0g1+XPXotLdrLO+iJfFRQvfkdfM=
 alpineworks.io/ootel v1.0.4/go.mod h1:ZCKCBy2Q0wVPO03iSSTfbv+GcL/5lU0d+SPH8hTwd3k=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=


### PR DESCRIPTION
Picks up alpineworks/go-litime-bluetooth#5.

v1.1.1 serialised scanning against scanning and connecting against connecting, but not scanning against connecting. `Connect` released the scan lock before taking the connect lock, so one battery's scan landed inside another's connection bring-up, and BlueZ aborts an in-flight connect when discovery starts.

The effect was that adding a second battery broke the first, with both reporting `le-connection-abort-by-local` — an error that points at the peers rather than at the callers colliding — and neither recovering, since every retry collided identically.

v1.1.2 holds a single per-adapter lock across scan, connect and service discovery. No changes are needed in this repo: `superviseBattery` constructs a client per attempt, so it picks up the corrected behaviour directly.

## Testing

Builds for darwin and linux/arm64; `go vet`, `gofmt` and the race tests are clean.

**Not hardware-verified.** This is the second attempt at this bug — the first (#4 / v1.1.1) also passed review and CI before failing on real hardware. The batteries have been unreachable since 06:39 UTC, so the two-battery path that actually exercises this has not been run.

Suggested order once hardware is back: confirm single-battery collection is stable, deploy this, then retry two batteries in a window where another outage is acceptable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)