### PR TITLE
feat: select the bluetooth adapter with BLUETOOTH_ADAPTER

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ readings into TimescaleDB.
 | --- | --- | --- |
 | `LITIME_BATTERIES` | | Batteries to poll, as `id=target` pairs separated by commas. |
 | `LITIME_BATTERY_BLUETOOTH_NAME` | | Single battery by advertised name. Used only when `LITIME_BATTERIES` is unset. |
+| `BLUETOOTH_ADAPTER` | | Adapter to use, e.g. `hci1`. Empty uses the default (`hci0`). Linux only. |
 | `TIMESCALE_CONN_STRING` | *required* | PostgreSQL/TimescaleDB connection string. |
 | `SCRAPE_INTERVAL` | `10s` | How often each battery is asked for a reading. |
 | `SCAN_TIMEOUT` | `30s` | How long to scan when resolving batteries by name. |
@@ -60,6 +61,33 @@ go run ./example/multi
 
 Addresses are MAC addresses on Linux but opaque CoreBluetooth UUIDs on macOS, so
 a value discovered on one operating system will not work on another.
+
+### WiFi and Bluetooth on a Raspberry Pi
+
+The Pi's onboard chip shares a single antenna between WiFi and Bluetooth. A busy
+2.4GHz WiFi link, especially a weak one where the radio transmits at high power
+for long stretches, starves Bluetooth badly enough to break it. The signature is
+distinctive and easy to misread as faulty hardware:
+
+- Scanning works and devices appear with a strong RSSI
+- Connections are *established* and then dropped within about half a second
+- `bluetoothctl` reports `le-connection-abort-by-local`, and `btmon` shows
+  `LE Connection Complete` followed by `Reason: Connection Failed to be
+  Established (0x3e)`
+- It affects every device, not just batteries, and survives reboots
+
+To confirm it, block WiFi briefly and retry the connection:
+
+```sh
+sudo rfkill block wifi && sleep 5
+bluetoothctl connect <address>
+sudo rfkill unblock wifi
+```
+
+If that connects, this is the problem. Fixes, best first: use Ethernet and
+disable WiFi; move Bluetooth to a USB dongle and select it with
+`BLUETOOTH_ADAPTER=hci1` (disable the onboard radio with `dtoverlay=disable-bt`
+so numbering stays stable); or improve the WiFi signal to reduce airtime.
 
 ## How it works
 

--- a/cmd/litime-timescaledb-inserter/main.go
+++ b/cmd/litime-timescaledb-inserter/main.go
@@ -122,6 +122,7 @@ func main() {
 		ScanTimeout:    c.ScanTimeout,
 		StaleTimeout:   c.StaleTimeout,
 		BufferSize:     c.ReadingBufferSize,
+		AdapterName:    c.BluetoothAdapter,
 		Logger:         slog.Default(),
 		Metrics:        metrics,
 	})
@@ -135,9 +136,15 @@ func main() {
 		managerDone <- manager.Run(ctx)
 	}()
 
+	adapter := c.BluetoothAdapter
+	if adapter == "" {
+		adapter = "default"
+	}
+
 	slog.Info("litime timescaledb inserter started",
 		slog.String("scrape_interval", c.ScrapeInterval.String()),
 		slog.String("stale_timeout", c.StaleTimeout.String()),
+		slog.String("bluetooth_adapter", adapter),
 		slog.Int("batteries", len(batteries)))
 
 	// Writing happens here rather than in the Bluetooth callbacks so that a slow

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,15 @@ type Config struct {
 	// predates LITIME_BATTERIES and is used only when that is unset.
 	LitimeBatteryBluetoothName string `env:"LITIME_BATTERY_BLUETOOTH_NAME"`
 
+	// BluetoothAdapter selects the adapter to use, for example "hci1". Empty
+	// uses the default, which is hci0.
+	//
+	// The Raspberry Pi's onboard chip shares one antenna between WiFi and
+	// Bluetooth, and a busy 2.4GHz WiFi link starves Bluetooth badly enough
+	// that connections are established and then dropped immediately. Moving to
+	// a USB dongle gives Bluetooth its own radio; the dongle comes up as hci1.
+	BluetoothAdapter string `env:"BLUETOOTH_ADAPTER"`
+
 	TimescaleConnString string        `env:"TIMESCALE_CONN_STRING,required"`
 	ScrapeInterval      time.Duration `env:"SCRAPE_INTERVAL" envDefault:"10s"`
 	CallbackTimeout     time.Duration `env:"CALLBACK_TIMEOUT" envDefault:"5s"`

--- a/internal/litime/adapter_linux.go
+++ b/internal/litime/adapter_linux.go
@@ -1,0 +1,23 @@
+//go:build linux
+
+package litime
+
+import (
+	tinygobluetooth "tinygo.org/x/bluetooth"
+)
+
+// resolveAdapter returns the Bluetooth adapter to use. An empty name selects
+// the default adapter, which is hci0.
+//
+// Naming an adapter matters when the host has more than one radio. The Pi's
+// onboard chip shares a single antenna between WiFi and Bluetooth, and a busy
+// 2.4GHz WiFi link starves Bluetooth badly enough that connections are
+// established and then immediately dropped. Moving Bluetooth to a USB dongle
+// gives it its own radio, and that dongle comes up as hci1.
+func resolveAdapter(name string) (*tinygobluetooth.Adapter, error) {
+	if name == "" {
+		return tinygobluetooth.DefaultAdapter, nil
+	}
+
+	return tinygobluetooth.NewAdapter(name), nil
+}

--- a/internal/litime/adapter_linux_test.go
+++ b/internal/litime/adapter_linux_test.go
@@ -1,0 +1,47 @@
+//go:build linux
+
+package litime
+
+import (
+	"testing"
+	"time"
+)
+
+// Naming an adapter is how a USB dongle gets used instead of the onboard radio,
+// so it has to be accepted and has to produce a distinct adapter.
+func TestResolveAdapterAcceptsName(t *testing.T) {
+	t.Parallel()
+
+	named, err := resolveAdapter("hci1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if named == nil {
+		t.Fatal("resolveAdapter returned nil for a named adapter")
+	}
+
+	def, err := resolveAdapter("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Falling back to the default would silently use the onboard radio, which
+	// is the exact thing naming an adapter is meant to avoid.
+	if named == def {
+		t.Error("named adapter resolved to the default adapter")
+	}
+}
+
+func TestNewManagerAcceptsAdapterName(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewManager(ManagerOptions{
+		Batteries:      []Battery{{ID: "garage", Match: MatchName, Value: "battery"}},
+		ScrapeInterval: time.Second,
+		StaleTimeout:   10 * time.Second,
+		AdapterName:    "hci1",
+	})
+	if err != nil {
+		t.Fatalf("naming an adapter should be accepted on linux, got: %v", err)
+	}
+}

--- a/internal/litime/adapter_other.go
+++ b/internal/litime/adapter_other.go
@@ -1,0 +1,23 @@
+//go:build !linux
+
+package litime
+
+import (
+	"fmt"
+
+	tinygobluetooth "tinygo.org/x/bluetooth"
+)
+
+// resolveAdapter returns the Bluetooth adapter to use.
+//
+// Only Linux exposes adapters by name; elsewhere the underlying stack offers a
+// single default adapter and nothing to select between. Naming one is rejected
+// rather than ignored, so a configuration that cannot be honoured fails at
+// startup instead of quietly using the wrong radio.
+func resolveAdapter(name string) (*tinygobluetooth.Adapter, error) {
+	if name != "" {
+		return nil, fmt.Errorf("selecting a bluetooth adapter by name is only supported on linux (got %q)", name)
+	}
+
+	return tinygobluetooth.DefaultAdapter, nil
+}

--- a/internal/litime/adapter_other_test.go
+++ b/internal/litime/adapter_other_test.go
@@ -1,0 +1,33 @@
+//go:build !linux
+
+package litime
+
+import (
+	"testing"
+	"time"
+)
+
+// Only Linux can select an adapter by name. Elsewhere the request must fail
+// loudly rather than fall back to the default, which would use a different
+// radio than the operator asked for.
+func TestResolveAdapterRejectsNameOffLinux(t *testing.T) {
+	t.Parallel()
+
+	if _, err := resolveAdapter("hci1"); err == nil {
+		t.Error("expected an error naming an adapter on a platform without adapter selection")
+	}
+}
+
+func TestNewManagerRejectsAdapterNameOffLinux(t *testing.T) {
+	t.Parallel()
+
+	_, err := NewManager(ManagerOptions{
+		Batteries:      []Battery{{ID: "garage", Match: MatchName, Value: "battery"}},
+		ScrapeInterval: time.Second,
+		StaleTimeout:   10 * time.Second,
+		AdapterName:    "hci1",
+	})
+	if err == nil {
+		t.Error("expected NewManager to reject a named adapter on this platform")
+	}
+}

--- a/internal/litime/adapter_test.go
+++ b/internal/litime/adapter_test.go
@@ -1,0 +1,18 @@
+package litime
+
+import "testing"
+
+// An unset adapter must keep working exactly as before on every platform, since
+// that is what existing deployments rely on.
+func TestResolveAdapterDefaultsWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	adapter, err := resolveAdapter("")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if adapter == nil {
+		t.Fatal("resolveAdapter returned a nil adapter for the default")
+	}
+}

--- a/internal/litime/manager.go
+++ b/internal/litime/manager.go
@@ -38,6 +38,10 @@ type ManagerOptions struct {
 	// BufferSize bounds the reading queue handed to the consumer.
 	BufferSize int
 
+	// AdapterName selects the Bluetooth adapter, for example "hci1". Empty
+	// means the default adapter. Only meaningful on Linux.
+	AdapterName string
+
 	Logger  *slog.Logger
 	Metrics *Metrics
 }
@@ -53,6 +57,7 @@ type Manager struct {
 	scrapeInterval time.Duration
 	scanTimeout    time.Duration
 	staleTimeout   time.Duration
+	adapter        *tinygobluetooth.Adapter
 	logger         *slog.Logger
 	metrics        *Metrics
 
@@ -94,11 +99,17 @@ func NewManager(opts ManagerOptions) (*Manager, error) {
 		return nil, fmt.Errorf("stale timeout (%s) must exceed scrape interval (%s)", opts.StaleTimeout, opts.ScrapeInterval)
 	}
 
+	adapter, err := resolveAdapter(opts.AdapterName)
+	if err != nil {
+		return nil, err
+	}
+
 	return &Manager{
 		batteries:      opts.Batteries,
 		scrapeInterval: opts.ScrapeInterval,
 		scanTimeout:    opts.ScanTimeout,
 		staleTimeout:   opts.StaleTimeout,
+		adapter:        adapter,
 		logger:         opts.Logger,
 		metrics:        opts.Metrics,
 		readings:       make(chan Reading, opts.BufferSize),
@@ -181,6 +192,7 @@ func (m *Manager) resolveAddresses(ctx context.Context) (map[string]tinygoblueto
 	m.logger.Info("scanning for batteries by name", slog.Any("names", names))
 
 	devices, err := bluetooth.ScanForDevices(ctx,
+		bluetooth.ScanWithAdapter(m.adapter),
 		bluetooth.ScanWithLogger(m.logger),
 		bluetooth.ScanWithTimeout(m.scanTimeout),
 		bluetooth.ScanWithNames(names...),
@@ -302,6 +314,7 @@ func (m *Manager) connect(ctx context.Context, battery Battery, address tinygobl
 
 	client := bluetooth.NewLiTimeBluetoothClient(battery.Value,
 		bluetooth.WithAddress(address),
+		bluetooth.WithAdapter(m.adapter),
 		bluetooth.WithLogger(logger),
 		bluetooth.WithScanTimeout(m.scanTimeout),
 		bluetooth.WithEnableNotificationCallback(func(b []byte) {


### PR DESCRIPTION
Adds `BLUETOOTH_ADAPTER` so Bluetooth can be moved to a USB dongle.

## Why

The Raspberry Pi's onboard chip shares a single antenna between WiFi and Bluetooth. A busy 2.4GHz WiFi link — especially a weak one, where the radio transmits at high power for long stretches — starves Bluetooth badly enough to break it.

The signature is easy to misdiagnose as faulty hardware:

- Scanning works, devices appear with strong RSSI
- Connections are **established** and then dropped within ~0.5s
- `bluetoothctl` reports `le-connection-abort-by-local`; `btmon` shows `LE Connection Complete` (success) followed by `Reason: Connection Failed to be Established (0x3e)`
- Every device is affected, not just batteries, and it survives reboots and power cycles

Confirmed on hardware: with `rfkill block wifi`, two LiTime batteries and a Victron SmartSolar all connected immediately and resolved services. With WiFi up, all three failed identically.

Moving Bluetooth to a USB dongle gives it an independent radio, but the dongle enumerates as `hci1` and the code had no way to select it.

## What this does

`BLUETOOTH_ADAPTER=hci1` is threaded through to both the address-resolution scan and the per-battery clients. Empty keeps the current behaviour (`hci0`).

Adapter selection only exists on Linux, so naming one on another platform is rejected at startup rather than silently falling back to the default — falling back would use a different radio than the operator asked for, which is the precise failure this feature exists to avoid. That's a build-tagged split, with tests on both sides.

The selected adapter is logged at startup, and the README gains a section on recognising and confirming the coexistence failure, including the `rfkill` test.

## Testing

Builds for darwin and linux/arm64; `-race` tests pass on both; `go vet`, `gofmt` and `golangci-lint` v2.1.6 clean.

Tests cover the default staying usable everywhere, a named adapter resolving to something distinct from the default on Linux, and rejection off Linux.

Not exercised with an actual dongle — no second adapter is available yet. The `hci1` path is therefore unproven against real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)