### PR TITLE
fix: release with GH_RELEASE_PAT so images publish

### DIFF
--- a/.github/workflows/push_main.yml
+++ b/.github/workflows/push_main.yml
@@ -10,8 +10,6 @@ jobs:
   release:
     name: "Release to GitHub"
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
     steps:
       - name: Checkout repo
         uses: actions/checkout@v3
@@ -26,5 +24,5 @@ jobs:
 
       - name: Release Version
         env:
-          GITHUB_TOKEN: ${{ github.token }}
+          GITHUB_TOKEN: ${{ secrets.GH_RELEASE_PAT }}
         run: npx semantic-release@22.0.12


### PR DESCRIPTION
Brings this repo in line with `alpineworks/ootel`, `rfc9457` and `gomediamtx`. The workflow file is now byte-identical to theirs.

## Two problems this fixes

**Container images have never published.** `upload_image.yml` triggers on `release: created`, but the release was being created by semantic-release using the built-in `GITHUB_TOKEN`. GitHub deliberately does not start new workflow runs from events raised by that token — it is the loop-prevention safeguard — so the event never reached the image workflow.

The result: every release since `v0.0.1` produced a GitHub release with no container image. `ghcr.io/michaelpeterswa/litime-timescaledb-inserter:latest` still points at the August `v0.0.1` build, which is the single-battery version. The `v0.0.1` image exists only because that release was created by hand in the UI, where the event fires normally.

**The success step failed on every release.** The built-in token had only `contents: write`, but commenting on the PRs included in a release needs `issues: write` and `pull-requests: write`:

```
✘  Not allowed to add a comment to the issue #3.
✘  Not allowed to add a comment to the issue #2.
✘  Not allowed to add a comment to the issue #1.
```

Non-fatal, but it recurred on every release.

## The change

`secrets.GH_RELEASE_PAT` (already present on this repo) replaces `github.token`. Events raised by a PAT do start workflows, and the PAT carries the scopes the comment step needs.

The `permissions:` block is removed with it — it only ever governed the built-in token, which is no longer used, and the sibling repos do not have it.

## Why `fix:` and not `ci:`

`ci:` would not cut a release under the conventionalcommits preset, and a release is exactly what exercises this. Typing it as `fix:` means merging produces a patch release, and we can confirm `Upload Image` actually runs and pushes to ghcr — which is the only real verification available.

Worth watching after merge: the `Release Version` run should succeed with no comment errors, and an `Upload Image` run should appear immediately afterwards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)