### PR TITLE
feat: collect from victron solar chargers

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ readings into TimescaleDB.
 | --- | --- | --- |
 | `LITIME_BATTERIES` | | Batteries to poll, as `id=target` pairs separated by commas. |
 | `LITIME_BATTERY_BLUETOOTH_NAME` | | Single battery by advertised name. Used only when `LITIME_BATTERIES` is unset. |
+| `VICTRON_DEVICES` | | Victron devices to read, as `id=address` pairs. Unset disables Victron collection. |
+| `VICTRON_KEYS` | | Advertisement keys for those devices, as `id=key` pairs. **Credentials.** |
+| `VICTRON_SCAN_INTERVAL` | `60s` | How often to scan for Victron advertisements. |
+| `VICTRON_SCAN_DURATION` | `5s` | Length of a single Victron scan. Must be shorter than the interval. |
 | `BLUETOOTH_ADAPTER` | | Adapter to use, e.g. `hci1`. Empty uses the default (`hci0`). Linux only. |
 | `TIMESCALE_CONN_STRING` | *required* | PostgreSQL/TimescaleDB connection string. |
 | `SCRAPE_INTERVAL` | `10s` | How often each battery is asked for a reading. |
@@ -61,6 +65,37 @@ go run ./example/multi
 
 Addresses are MAC addresses on Linux but opaque CoreBluetooth UUIDs on macOS, so
 a value discovered on one operating system will not work on another.
+
+### Victron solar chargers
+
+Victron devices broadcast their state in the BLE advertisement rather than
+exposing it over a connection, so reading them is passive — no connection, no
+pairing, no GATT:
+
+```sh
+VICTRON_DEVICES="smartsolar=F9:E3:C4:6E:85:D9"
+VICTRON_KEYS="smartsolar=<advertisement key>"
+```
+
+The advertisement key comes from VictronConnect: select the device, then
+**Settings → Product Info → Instant Readout Details → Show**. It is a credential
+and belongs in a secret alongside the database password. It **changes if the
+device's Bluetooth PIN is reset**.
+
+Both variables are keyed by the same operator-chosen device ID, and every
+configured device needs an entry in each. A device without a key can be seen but
+never decrypted, and a key naming a device that is not configured is almost
+always a typo, so both are startup errors rather than silent omissions.
+
+Scanning shares the radio with the batteries and is serialised against their
+connections, which is why this runs in the same process rather than beside it.
+Each scan holds the radio, so battery reconnects queue behind it — keep
+`VICTRON_SCAN_DURATION` short relative to `VICTRON_SCAN_INTERVAL`. Readings land
+in `sensors.victron`.
+
+Because there is no connection to lose, the only sign that a Victron device has
+gone quiet is the absence of readings; `victron_missed` counts scans that
+produced nothing for a configured device and is the metric worth alerting on.
 
 ### WiFi and Bluetooth on a Raspberry Pi
 

--- a/cmd/litime-timescaledb-inserter/main.go
+++ b/cmd/litime-timescaledb-inserter/main.go
@@ -136,6 +136,16 @@ func main() {
 		managerDone <- manager.Run(ctx)
 	}()
 
+	// Victron devices are optional, and share the battery manager's adapter so
+	// that scanning for them is serialised against battery connections. A
+	// separate adapter would sit outside that lock and abort connections
+	// mid-establishment.
+	victronDone, victronDevices, err := startVictron(ctx, c, manager.Adapter(), timescaleClient)
+	if err != nil {
+		slog.Error("could not start victron collector", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+
 	adapter := c.BluetoothAdapter
 	if adapter == "" {
 		adapter = "default"
@@ -145,7 +155,8 @@ func main() {
 		slog.String("scrape_interval", c.ScrapeInterval.String()),
 		slog.String("stale_timeout", c.StaleTimeout.String()),
 		slog.String("bluetooth_adapter", adapter),
-		slog.Int("batteries", len(batteries)))
+		slog.Int("batteries", len(batteries)),
+		slog.Int("victron_devices", victronDevices))
 
 	// Writing happens here rather than in the Bluetooth callbacks so that a slow
 	// database cannot stall notification dispatch. The loop ends when the
@@ -156,6 +167,11 @@ func main() {
 
 	if err := <-managerDone; err != nil {
 		slog.Error("battery manager stopped with an error", slog.String("error", err.Error()))
+		os.Exit(1)
+	}
+
+	if err := <-victronDone; err != nil {
+		slog.Error("victron collector stopped with an error", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
 

--- a/cmd/litime-timescaledb-inserter/victron.go
+++ b/cmd/litime-timescaledb-inserter/victron.go
@@ -1,0 +1,131 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"time"
+
+	"github.com/michaelpeterswa/litime-timescaledb-inserter/internal/config"
+	"github.com/michaelpeterswa/litime-timescaledb-inserter/internal/timescale"
+	"github.com/michaelpeterswa/litime-timescaledb-inserter/internal/victron"
+	tinygobluetooth "tinygo.org/x/bluetooth"
+)
+
+// startVictron brings up Victron collection if any devices are configured,
+// returning a channel that reports how it finished and the number of devices.
+//
+// Victron support is optional: with nothing configured the returned channel
+// yields nil immediately, so the caller can wait on it unconditionally.
+func startVictron(
+	ctx context.Context,
+	c *config.Config,
+	adapter *tinygobluetooth.Adapter,
+	timescaleClient *timescale.TimescaleClient,
+) (<-chan error, int, error) {
+	done := make(chan error, 1)
+
+	devices, err := victron.ParseDevices(c.VictronDevices, c.VictronKeys)
+	if err != nil {
+		return nil, 0, err
+	}
+
+	if len(devices) == 0 {
+		done <- nil
+		close(done)
+		return done, 0, nil
+	}
+
+	metrics, err := victron.NewMetrics()
+	if err != nil {
+		return nil, 0, err
+	}
+
+	collector, err := victron.NewCollector(victron.CollectorOptions{
+		Devices:      devices,
+		ScanInterval: c.VictronScanInterval,
+		ScanDuration: c.VictronScanDuration,
+		BufferSize:   c.ReadingBufferSize,
+		Adapter:      adapter,
+		Logger:       slog.Default(),
+		Metrics:      metrics,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+
+	for _, device := range devices {
+		// The key is deliberately not logged.
+		slog.Info("victron device configured",
+			slog.String("device_id", device.ID),
+			slog.String("address", device.Address))
+	}
+
+	collectorDone := make(chan error, 1)
+	go func() {
+		collectorDone <- collector.Run(ctx)
+	}()
+
+	go func() {
+		// Draining to completion matters: the collector closes the queue when
+		// it stops, and readings still in it are written before we report done.
+		for reading := range collector.Readings() {
+			insertVictron(ctx, timescaleClient, metrics, c.CallbackTimeout, reading)
+		}
+		done <- <-collectorDone
+		close(done)
+	}()
+
+	return done, len(devices), nil
+}
+
+// insertVictron writes one reading, using a background context so that readings
+// still queued at shutdown are not abandoned mid-write.
+func insertVictron(
+	ctx context.Context,
+	client *timescale.TimescaleClient,
+	metrics *victron.Metrics,
+	timeout time.Duration,
+	reading victron.Reading,
+) {
+	insertCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
+	defer cancel()
+
+	measure := timescale.VictronMeasurement{
+		DeviceID:               reading.DeviceID,
+		ObservedAt:             reading.ObservedAt,
+		ModelID:                reading.ModelID,
+		ModelName:              reading.ModelName,
+		RecordType:             reading.RecordType,
+		BatteryVoltage:         reading.Data.BatteryVoltage,
+		BatteryChargingCurrent: reading.Data.BatteryChargingCurrent,
+		YieldToday:             reading.Data.YieldToday,
+		SolarPower:             reading.Data.SolarPower,
+		ExternalDeviceLoad:     reading.Data.ExternalDeviceLoad,
+	}
+
+	// The enums are stored as text so the table reads without a lookup, and
+	// stay NULL when the device reported the field as unavailable.
+	if reading.Data.ChargeState != nil {
+		state := reading.Data.ChargeState.String()
+		measure.ChargeState = &state
+	}
+	if reading.Data.ChargerError != nil {
+		chargerErr := reading.Data.ChargerError.String()
+		measure.ChargerError = &chargerErr
+	}
+
+	err := client.InsertVictron(insertCtx, measure)
+	metrics.RecordInsert(insertCtx, reading.DeviceID, err)
+
+	if err != nil {
+		slog.Error("failed to insert victron data into timescale",
+			slog.String("device_id", reading.DeviceID),
+			slog.String("error", err.Error()))
+		return
+	}
+
+	slog.Debug("inserted victron reading",
+		slog.String("device_id", reading.DeviceID),
+		slog.Any("solar_power", reading.Data.SolarPower),
+		slog.Any("battery_voltage", reading.Data.BatteryVoltage))
+}

--- a/docker/timescale/migrations/005_create_victron_table.down.sql
+++ b/docker/timescale/migrations/005_create_victron_table.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS sensors.victron_device_id_time_idx;
+
+DROP TABLE IF EXISTS sensors.victron;

--- a/docker/timescale/migrations/005_create_victron_table.up.sql
+++ b/docker/timescale/migrations/005_create_victron_table.up.sql
@@ -1,0 +1,31 @@
+-- Readings from Victron devices broadcasting Instant Readout over BLE.
+--
+-- device_id is operator-chosen and is the only thing tying a row to a physical
+-- unit, so it is required rather than defaulted. model and record_type come
+-- from the advertisement itself and are recorded so a replaced or reconfigured
+-- device is visible in the data rather than silently changing meaning.
+--
+-- Every reading is nullable because Victron encodes "not available" as a
+-- per-field sentinel. Storing those as 0 would be indistinguishable from a
+-- charger genuinely reporting no output.
+CREATE TABLE IF NOT EXISTS
+    sensors.victron (
+        time TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        device_id TEXT NOT NULL,
+        model_id INTEGER,
+        model_name TEXT,
+        record_type SMALLINT,
+        charge_state TEXT,
+        charger_error TEXT,
+        battery_voltage REAL,
+        battery_charging_current REAL,
+        yield_today REAL,
+        solar_power REAL,
+        external_device_load REAL
+    );
+
+SELECT
+    create_hypertable ('sensors.victron', 'time', if_not_exists => TRUE);
+
+-- Almost every query is "this device, recent first".
+CREATE INDEX IF NOT EXISTS victron_device_id_time_idx ON sensors.victron (device_id, time DESC);

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,8 @@ go 1.24
 toolchain go1.24.2
 
 require (
-	alpineworks.io/go-litime-bluetooth v1.1.2
+	alpineworks.io/go-litime-bluetooth v1.2.0
+	alpineworks.io/go-victron-ble v1.0.0
 	alpineworks.io/ootel v1.0.4
 	github.com/caarlos0/env/v11 v11.3.1
 	github.com/exaring/otelpgx v0.9.3

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,7 @@
-alpineworks.io/go-litime-bluetooth v1.1.2 h1:48knAE0PhaHFqzf+mCav49bMti5PZLkpl1n1qkGIKhQ=
-alpineworks.io/go-litime-bluetooth v1.1.2/go.mod h1:hmAPqfWiWDfnHssR8XurZl6kX3RdAAo6iMCnr63YytE=
+alpineworks.io/go-litime-bluetooth v1.2.0 h1:K0/273ywHwk2bwJ9LNJ0R/2IugMkfeles2+Z0Z3dcvM=
+alpineworks.io/go-litime-bluetooth v1.2.0/go.mod h1:hmAPqfWiWDfnHssR8XurZl6kX3RdAAo6iMCnr63YytE=
+alpineworks.io/go-victron-ble v1.0.0 h1:zhay5wb2URttQatrOBI3U6+m3P5UYJcFhHgY4sN+GAI=
+alpineworks.io/go-victron-ble v1.0.0/go.mod h1:3NjpS2G8z3lVaEQ9JVB2VkYjaaNYpgJNOPnAOiOoNrw=
 alpineworks.io/ootel v1.0.4 h1:NZrYyFsk8obdfhbs0g1+XPXotLdrLO+iJfFRQvfkdfM=
 alpineworks.io/ootel v1.0.4/go.mod h1:ZCKCBy2Q0wVPO03iSSTfbv+GcL/5lU0d+SPH8hTwd3k=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -23,6 +23,30 @@ type Config struct {
 	// predates LITIME_BATTERIES and is used only when that is unset.
 	LitimeBatteryBluetoothName string `env:"LITIME_BATTERY_BLUETOOTH_NAME"`
 
+	// VictronDevices maps an operator-chosen device ID to a Bluetooth device
+	// address, for example:
+	//
+	//	VICTRON_DEVICES="smartsolar=F9:E3:C4:6E:85:D9"
+	//
+	// Leave unset to disable Victron collection entirely.
+	VictronDevices map[string]string `env:"VICTRON_DEVICES" envKeyValSeparator:"="`
+
+	// VictronKeys maps those same device IDs to their advertisement keys, as
+	// shown by VictronConnect under Product Info, Instant Readout Details.
+	//
+	// These are credentials and belong in a secret alongside the database
+	// password. Note that a device's key changes if its Bluetooth PIN is reset.
+	VictronKeys map[string]string `env:"VICTRON_KEYS" envKeyValSeparator:"="`
+
+	// VictronScanInterval is how often Victron devices are scanned for. Each
+	// scan holds the radio, so battery reconnects queue behind it; the default
+	// is deliberately slow relative to the scan duration.
+	VictronScanInterval time.Duration `env:"VICTRON_SCAN_INTERVAL" envDefault:"60s"`
+
+	// VictronScanDuration bounds a single Victron scan. It must be shorter than
+	// the interval, or the radio is never free for anything else.
+	VictronScanDuration time.Duration `env:"VICTRON_SCAN_DURATION" envDefault:"5s"`
+
 	// BluetoothAdapter selects the adapter to use, for example "hci1". Empty
 	// uses the default, which is hci0.
 	//

--- a/internal/litime/manager.go
+++ b/internal/litime/manager.go
@@ -116,6 +116,16 @@ func NewManager(opts ManagerOptions) (*Manager, error) {
 	}, nil
 }
 
+// Adapter returns the Bluetooth adapter this manager uses.
+//
+// Anything else in the process that touches the radio must use this same
+// adapter. The Bluetooth library serialises scanning and connecting per
+// adapter, so a second collector resolving its own would sit outside that lock
+// and abort connections mid-establishment.
+func (m *Manager) Adapter() *tinygobluetooth.Adapter {
+	return m.adapter
+}
+
 // Readings returns the channel every battery publishes to. It is closed once Run
 // has returned and no further readings will arrive.
 func (m *Manager) Readings() <-chan Reading {

--- a/internal/timescale/queries/insert_victron.pgsql
+++ b/internal/timescale/queries/insert_victron.pgsql
@@ -1,0 +1,30 @@
+INSERT INTO
+    sensors.victron (
+        time,
+        device_id,
+        model_id,
+        model_name,
+        record_type,
+        charge_state,
+        charger_error,
+        battery_voltage,
+        battery_charging_current,
+        yield_today,
+        solar_power,
+        external_device_load
+    )
+VALUES
+    (
+        $1,
+        $2,
+        $3,
+        $4,
+        $5,
+        $6,
+        $7,
+        $8,
+        $9,
+        $10,
+        $11,
+        $12
+    );

--- a/internal/timescale/timescale.go
+++ b/internal/timescale/timescale.go
@@ -81,6 +81,53 @@ func (c *TimescaleClient) Insert(ctx context.Context, batteryID string, observed
 	return nil
 }
 
+//go:embed queries/insert_victron.pgsql
+var insertVictron string
+
+// VictronMeasurement is one decoded Victron solar charger advertisement.
+//
+// The readings are pointers because Victron encodes "not available" per field.
+// They are stored as NULL rather than zero, since a charger reporting nothing
+// and a charger reporting no output are different states.
+type VictronMeasurement struct {
+	DeviceID   string
+	ObservedAt time.Time
+	ModelID    uint16
+	ModelName  string
+	RecordType uint8
+
+	ChargeState            *string
+	ChargerError           *string
+	BatteryVoltage         *float64
+	BatteryChargingCurrent *float64
+	YieldToday             *float64
+	SolarPower             *float64
+	ExternalDeviceLoad     *float64
+}
+
+// InsertVictron records one Victron reading.
+func (c *TimescaleClient) InsertVictron(ctx context.Context, measure VictronMeasurement) error {
+	_, err := c.Pool.Exec(ctx, insertVictron,
+		measure.ObservedAt,
+		measure.DeviceID,
+		int32(measure.ModelID),
+		measure.ModelName,
+		int16(measure.RecordType),
+		measure.ChargeState,
+		measure.ChargerError,
+		measure.BatteryVoltage,
+		measure.BatteryChargingCurrent,
+		measure.YieldToday,
+		measure.SolarPower,
+		measure.ExternalDeviceLoad,
+	)
+	if err != nil {
+		return fmt.Errorf("insert victron data: %w", err)
+	}
+
+	return nil
+}
+
 func mapCellVoltages(cellVoltages []float32) map[string]float32 {
 	voltages := make(map[string]float32, len(cellVoltages))
 	for i, voltage := range cellVoltages {

--- a/internal/victron/collector.go
+++ b/internal/victron/collector.go
@@ -1,0 +1,292 @@
+package victron
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+	"strings"
+	"sync"
+	"time"
+
+	litimebluetooth "alpineworks.io/go-litime-bluetooth/bluetooth"
+	victronble "alpineworks.io/go-victron-ble"
+	tinygobluetooth "tinygo.org/x/bluetooth"
+)
+
+// Reading is one decoded solar charger advertisement.
+type Reading struct {
+	DeviceID   string
+	ObservedAt time.Time
+	ModelID    uint16
+	ModelName  string
+	RecordType uint8
+	Data       *victronble.SolarCharger
+}
+
+// CollectorOptions configures a Collector.
+type CollectorOptions struct {
+	Devices []Device
+
+	// ScanInterval is how often a scan runs. Each scan holds the radio, so
+	// device connections elsewhere in the process queue behind it; a short scan
+	// on a slow interval keeps that window small.
+	ScanInterval time.Duration
+
+	// ScanDuration bounds a single scan.
+	ScanDuration time.Duration
+
+	// BufferSize bounds the reading queue handed to the consumer.
+	BufferSize int
+
+	Adapter *tinygobluetooth.Adapter
+	Logger  *slog.Logger
+	Metrics *Metrics
+}
+
+// Collector reads Victron devices by observing their advertisements.
+//
+// Victron broadcasts state in the advertisement rather than exposing it over a
+// connection, so this never connects to anything: it scans, decrypts what it
+// saw, and publishes. Scans go through the Bluetooth library so they are
+// serialised against connections made elsewhere on the same adapter, which is
+// the whole reason this lives in the same process as the battery collector
+// rather than beside it.
+type Collector struct {
+	devices      []Device
+	byAddress    map[string]Device
+	scanInterval time.Duration
+	scanDuration time.Duration
+	adapter      *tinygobluetooth.Adapter
+	logger       *slog.Logger
+	metrics      *Metrics
+
+	readings chan Reading
+	// closeMu guards closing readings. Nothing publishes after Run returns, but
+	// the guard keeps that a property of the code rather than of the ordering.
+	closeMu sync.RWMutex
+	closed  bool
+}
+
+func NewCollector(opts CollectorOptions) (*Collector, error) {
+	if len(opts.Devices) == 0 {
+		return nil, fmt.Errorf("no victron devices configured")
+	}
+	if opts.Logger == nil {
+		opts.Logger = slog.Default()
+	}
+	if opts.BufferSize <= 0 {
+		opts.BufferSize = 64
+	}
+	if opts.ScanInterval <= 0 {
+		opts.ScanInterval = time.Minute
+	}
+	if opts.ScanDuration <= 0 {
+		opts.ScanDuration = 5 * time.Second
+	}
+	if opts.ScanDuration >= opts.ScanInterval {
+		return nil, fmt.Errorf("scan duration (%s) must be shorter than the scan interval (%s), or the radio is never free", opts.ScanDuration, opts.ScanInterval)
+	}
+	if opts.Adapter == nil {
+		return nil, fmt.Errorf("no bluetooth adapter provided")
+	}
+
+	byAddress := make(map[string]Device, len(opts.Devices))
+	for _, device := range opts.Devices {
+		byAddress[device.Address] = device
+	}
+
+	return &Collector{
+		devices:      opts.Devices,
+		byAddress:    byAddress,
+		scanInterval: opts.ScanInterval,
+		scanDuration: opts.ScanDuration,
+		adapter:      opts.Adapter,
+		logger:       opts.Logger,
+		metrics:      opts.Metrics,
+		readings:     make(chan Reading, opts.BufferSize),
+	}, nil
+}
+
+// Readings returns the channel decoded advertisements are published on. It is
+// closed once Run has returned.
+func (c *Collector) Readings() <-chan Reading {
+	return c.readings
+}
+
+// Run scans on an interval until ctx is cancelled.
+func (c *Collector) Run(ctx context.Context) error {
+	defer c.closeReadings()
+
+	// Scan immediately so a restart produces data without waiting out a full
+	// interval.
+	c.scanOnce(ctx)
+
+	ticker := time.NewTicker(c.scanInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-ticker.C:
+			c.scanOnce(ctx)
+		}
+	}
+}
+
+func (c *Collector) scanOnce(ctx context.Context) {
+	addresses := make([]tinygobluetooth.Address, 0, len(c.devices))
+	for _, device := range c.devices {
+		address, err := litimebluetooth.ParseAddress(device.Address)
+		if err != nil {
+			// Addresses were validated at startup, so this cannot normally
+			// happen; skipping beats aborting the whole scan.
+			c.logger.Error("skipping victron device with unparseable address",
+				slog.String("device_id", device.ID),
+				slog.String("address", device.Address),
+				slog.String("error", err.Error()))
+			continue
+		}
+		addresses = append(addresses, address)
+	}
+
+	if len(addresses) == 0 {
+		return
+	}
+
+	devices, err := litimebluetooth.ScanForDevices(ctx,
+		litimebluetooth.ScanWithAdapter(c.adapter),
+		litimebluetooth.ScanWithLogger(c.logger),
+		litimebluetooth.ScanWithTimeout(c.scanDuration),
+		litimebluetooth.ScanWithAddresses(addresses...),
+	)
+	if err != nil {
+		if ctx.Err() != nil {
+			return
+		}
+		c.logger.Error("victron scan failed", slog.String("error", err.Error()))
+		c.metrics.recordScanFailure(ctx)
+		return
+	}
+
+	seen := make(map[string]struct{}, len(devices))
+	for _, found := range devices {
+		device, ok := c.byAddress[strings.ToUpper(found.Address.String())]
+		if !ok {
+			continue
+		}
+
+		if c.handle(ctx, device, found) {
+			seen[device.ID] = struct{}{}
+		}
+	}
+
+	// A device that advertised nothing this round is worth surfacing: it is the
+	// only signal that a passive collector has lost sight of something, since
+	// there is no connection to drop.
+	for _, device := range c.devices {
+		if _, ok := seen[device.ID]; !ok {
+			c.logger.Warn("no victron reading this scan", slog.String("device_id", device.ID))
+			c.metrics.recordMissed(ctx, device.ID)
+		}
+	}
+}
+
+// handle decodes one scan result, reporting whether a reading was published.
+func (c *Collector) handle(ctx context.Context, device Device, found litimebluetooth.DiscoveredDevice) bool {
+	data, ok := found.ManufacturerData[victronble.CompanyID]
+	if !ok {
+		return false
+	}
+
+	record, err := victronble.ParseRecord(data)
+	if err != nil {
+		// Victron uses manufacturer data for records other than instant
+		// readout, so this is routine rather than a fault.
+		c.logger.Debug("skipping victron advertisement",
+			slog.String("device_id", device.ID),
+			slog.String("reason", err.Error()))
+		return false
+	}
+
+	if record.Type != victronble.RecordSolarCharger {
+		c.logger.Debug("ignoring unsupported victron record type",
+			slog.String("device_id", device.ID),
+			slog.String("record_type", record.Type.String()))
+		return false
+	}
+
+	payload, err := victronble.Decrypt(record, device.Key)
+	if err != nil {
+		// A key mismatch is a configuration error that will not fix itself, so
+		// it is worth more noise than a malformed frame.
+		var mismatch *victronble.ErrKeyMismatch
+		if errors.As(err, &mismatch) {
+			c.logger.Error("victron encryption key does not match this device",
+				slog.String("device_id", device.ID),
+				slog.String("error", err.Error()))
+		} else {
+			c.logger.Warn("failed to decrypt victron advertisement",
+				slog.String("device_id", device.ID),
+				slog.String("error", err.Error()))
+		}
+		c.metrics.recordDecryptFailure(ctx, device.ID)
+		return false
+	}
+
+	charger, err := victronble.ParseSolarCharger(payload)
+	if err != nil {
+		c.logger.Warn("failed to parse victron payload",
+			slog.String("device_id", device.ID),
+			slog.String("error", err.Error()))
+		c.metrics.recordDecodeFailure(ctx, device.ID)
+		return false
+	}
+
+	modelName, _ := victronble.ModelName(record.ModelID)
+
+	reading := Reading{
+		DeviceID:   device.ID,
+		ObservedAt: time.Now(),
+		ModelID:    record.ModelID,
+		ModelName:  modelName,
+		RecordType: uint8(record.Type),
+		Data:       charger,
+	}
+
+	if !c.publish(reading) {
+		c.logger.Warn("victron reading queue full, dropping reading", slog.String("device_id", device.ID))
+		c.metrics.recordDropped(ctx, device.ID)
+		return true
+	}
+
+	c.metrics.recordReading(ctx, device.ID)
+
+	return true
+}
+
+// publish offers a reading without blocking the scan loop.
+func (c *Collector) publish(reading Reading) bool {
+	c.closeMu.RLock()
+	defer c.closeMu.RUnlock()
+
+	if c.closed {
+		return false
+	}
+
+	select {
+	case c.readings <- reading:
+		return true
+	default:
+		return false
+	}
+}
+
+func (c *Collector) closeReadings() {
+	c.closeMu.Lock()
+	defer c.closeMu.Unlock()
+
+	c.closed = true
+	close(c.readings)
+}

--- a/internal/victron/device.go
+++ b/internal/victron/device.go
@@ -1,0 +1,92 @@
+package victron
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	litimebluetooth "alpineworks.io/go-litime-bluetooth/bluetooth"
+	victronble "alpineworks.io/go-victron-ble"
+)
+
+// Device is one configured Victron device to read.
+type Device struct {
+	// ID is the stable identifier recorded alongside every reading. It is
+	// operator-chosen, so replacing hardware does not rewrite history under a
+	// different key.
+	ID string
+
+	// Address is the BLE device address, upper-cased for comparison against
+	// scan results.
+	Address string
+
+	// Key is the 16 byte advertisement key from VictronConnect.
+	Key []byte
+}
+
+// ParseDevices builds the device list from configuration.
+//
+// addresses maps an operator-chosen ID to a device address; keys maps the same
+// IDs to their advertisement keys. Both are required for every device: an
+// address without a key cannot be decrypted, and a key without an address
+// belongs to a device that is not configured, which is more likely a typo than
+// an intention.
+func ParseDevices(addresses, keys map[string]string) ([]Device, error) {
+	if len(addresses) == 0 {
+		return nil, nil
+	}
+
+	devices := make([]Device, 0, len(addresses))
+	seen := make(map[string]string, len(addresses))
+
+	for id, address := range addresses {
+		id = strings.TrimSpace(id)
+		address = strings.TrimSpace(address)
+
+		if id == "" {
+			return nil, fmt.Errorf("victron device id must not be empty")
+		}
+		if address == "" {
+			return nil, fmt.Errorf("victron device %q has no address", id)
+		}
+
+		// Parsing here rather than at connect time means a mistyped address is
+		// a startup failure instead of a device that is simply never seen.
+		parsed, err := litimebluetooth.ParseAddress(address)
+		if err != nil {
+			return nil, fmt.Errorf("victron device %q: %w", id, err)
+		}
+
+		rawKey, ok := keys[id]
+		if !ok {
+			return nil, fmt.Errorf("victron device %q has no encryption key; set one in VICTRON_KEYS", id)
+		}
+
+		key, err := victronble.ParseKey(strings.TrimSpace(rawKey))
+		if err != nil {
+			return nil, fmt.Errorf("victron device %q: %w", id, err)
+		}
+
+		normalised := strings.ToUpper(parsed.String())
+		if previous, duplicate := seen[normalised]; duplicate {
+			return nil, fmt.Errorf("victron devices %q and %q both refer to %s", previous, id, normalised)
+		}
+		seen[normalised] = id
+
+		devices = append(devices, Device{ID: id, Address: normalised, Key: key})
+	}
+
+	// A key naming a device that is not configured is almost always a typo in
+	// one of the two variables, and silently ignoring it would leave the device
+	// unread with no indication why.
+	for id := range keys {
+		if _, ok := addresses[strings.TrimSpace(id)]; !ok {
+			return nil, fmt.Errorf("victron key %q has no matching entry in VICTRON_DEVICES", id)
+		}
+	}
+
+	// Map iteration is randomised, so sort for stable logs and startup order.
+	sort.Slice(devices, func(i, j int) bool { return devices[i].ID < devices[j].ID })
+
+	return devices, nil
+}

--- a/internal/victron/device_test.go
+++ b/internal/victron/device_test.go
@@ -1,0 +1,149 @@
+package victron
+
+import "testing"
+
+const (
+	// A syntactically valid 16 byte advertisement key. Not a real device key.
+	testKey      = "000102030405060708090a0b0c0d0e0f"
+	otherTestKey = "0f0e0d0c0b0a09080706050403020100"
+)
+
+func TestParseDevicesEmptyIsNotAnError(t *testing.T) {
+	t.Parallel()
+
+	// Victron support is optional, so no configuration means no devices rather
+	// than a failure to start.
+	devices, err := ParseDevices(nil, nil)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(devices) != 0 {
+		t.Errorf("got %d devices, want none", len(devices))
+	}
+}
+
+func TestParseDevicesRequiresAKeyPerDevice(t *testing.T) {
+	t.Parallel()
+
+	// A device with no key can be seen but never decrypted, which would look
+	// like a device that is present but silent.
+	_, err := ParseDevices(
+		map[string]string{"smartsolar": "11:22:33:AA:BB:CC"},
+		nil,
+	)
+	if err == nil {
+		t.Fatal("expected an error when a device has no encryption key")
+	}
+}
+
+func TestParseDevicesRejectsOrphanedKey(t *testing.T) {
+	t.Parallel()
+
+	// A key naming a device that is not configured is almost always a typo in
+	// one of the two variables. Ignoring it would leave a device unread with no
+	// indication why.
+	_, err := ParseDevices(
+		map[string]string{"smartsolar": "11:22:33:AA:BB:CC"},
+		map[string]string{"smartsolar": testKey, "typo": otherTestKey},
+	)
+	if err == nil {
+		t.Fatal("expected an error for a key with no matching device")
+	}
+}
+
+func TestParseDevicesRejectsBadKey(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		key  string
+	}{
+		{name: "not hex", key: "not-a-key"},
+		{name: "too short", key: "0011223344"},
+		{name: "too long", key: testKey + "00"},
+		{name: "empty", key: ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			_, err := ParseDevices(
+				map[string]string{"smartsolar": "11:22:33:AA:BB:CC"},
+				map[string]string{"smartsolar": tt.key},
+			)
+			if err == nil {
+				t.Error("expected an error, got nil")
+			}
+		})
+	}
+}
+
+func TestParseDevicesRejectsBadInput(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name      string
+		addresses map[string]string
+		keys      map[string]string
+	}{
+		{
+			name:      "empty id",
+			addresses: map[string]string{"": "11:22:33:AA:BB:CC"},
+			keys:      map[string]string{"": testKey},
+		},
+		{
+			name:      "empty address",
+			addresses: map[string]string{"smartsolar": ""},
+			keys:      map[string]string{"smartsolar": testKey},
+		},
+		{
+			name:      "unparseable address",
+			addresses: map[string]string{"smartsolar": "not-an-address"},
+			keys:      map[string]string{"smartsolar": testKey},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+
+			if _, err := ParseDevices(tt.addresses, tt.keys); err == nil {
+				t.Error("expected an error, got nil")
+			}
+		})
+	}
+}
+
+func TestNewCollectorRejectsScanLongerThanInterval(t *testing.T) {
+	t.Parallel()
+
+	// A scan holds the radio, so one lasting as long as the interval would
+	// leave it permanently busy and starve battery reconnects.
+	_, err := NewCollector(CollectorOptions{
+		Devices:      []Device{{ID: "smartsolar", Address: "11:22:33:AA:BB:CC", Key: make([]byte, 16)}},
+		ScanInterval: 5 * 1e9,
+		ScanDuration: 5 * 1e9,
+	})
+	if err == nil {
+		t.Fatal("expected an error when the scan duration is not shorter than the interval")
+	}
+}
+
+func TestNewCollectorRequiresDevicesAndAdapter(t *testing.T) {
+	t.Parallel()
+
+	if _, err := NewCollector(CollectorOptions{}); err == nil {
+		t.Error("expected an error with no devices configured")
+	}
+
+	// An adapter is required rather than defaulted, so that this collector
+	// cannot silently use a different radio than the rest of the process.
+	_, err := NewCollector(CollectorOptions{
+		Devices: []Device{{ID: "smartsolar", Address: "11:22:33:AA:BB:CC", Key: make([]byte, 16)}},
+	})
+	if err == nil {
+		t.Error("expected an error with no adapter provided")
+	}
+}

--- a/internal/victron/metrics.go
+++ b/internal/victron/metrics.go
@@ -1,0 +1,121 @@
+package victron
+
+import (
+	"context"
+
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/metric"
+)
+
+const meterName = "github.com/michaelpeterswa/litime-timescaledb-inserter/victron"
+
+// Metrics reports per-device collection health.
+//
+// A passive collector has no connection to lose, so the only evidence that a
+// device has gone quiet is the absence of readings. That makes the missed
+// counter the one worth alerting on.
+type Metrics struct {
+	readings        metric.Int64Counter
+	missed          metric.Int64Counter
+	decryptFailures metric.Int64Counter
+	decodeFailures  metric.Int64Counter
+	scanFailures    metric.Int64Counter
+	dropped         metric.Int64Counter
+	inserts         metric.Int64Counter
+	insertErrors    metric.Int64Counter
+}
+
+func NewMetrics() (*Metrics, error) {
+	meter := otel.Meter(meterName)
+
+	// counter returns the first error encountered, so only the final check is
+	// needed rather than one after every counter.
+	var err error
+	counter := func(name, description string) metric.Int64Counter {
+		c, cErr := meter.Int64Counter(name, metric.WithDescription(description))
+		if cErr != nil && err == nil {
+			err = cErr
+		}
+		return c
+	}
+
+	m := &Metrics{
+		readings:        counter("victron.readings", "Advertisements decoded from a Victron device"),
+		missed:          counter("victron.missed", "Scans that produced no advertisement for a configured device"),
+		decryptFailures: counter("victron.decrypt_failures", "Advertisements that could not be decrypted"),
+		decodeFailures:  counter("victron.decode_failures", "Advertisements that decrypted but could not be parsed"),
+		scanFailures:    counter("victron.scan_failures", "Scans that failed outright"),
+		dropped:         counter("victron.readings_dropped", "Readings discarded because the write queue was full"),
+		inserts:         counter("victron.inserts", "Readings written to the database"),
+		insertErrors:    counter("victron.insert_errors", "Readings that failed to be written to the database"),
+	}
+
+	if err != nil {
+		return nil, err
+	}
+
+	return m, nil
+}
+
+// The recorders below tolerate a nil receiver so metrics stay optional.
+
+func device(id string) metric.MeasurementOption {
+	return metric.WithAttributes(attribute.String("device_id", id))
+}
+
+func (m *Metrics) recordReading(ctx context.Context, deviceID string) {
+	if m == nil {
+		return
+	}
+	m.readings.Add(ctx, 1, device(deviceID))
+}
+
+func (m *Metrics) recordMissed(ctx context.Context, deviceID string) {
+	if m == nil {
+		return
+	}
+	m.missed.Add(ctx, 1, device(deviceID))
+}
+
+func (m *Metrics) recordDecryptFailure(ctx context.Context, deviceID string) {
+	if m == nil {
+		return
+	}
+	m.decryptFailures.Add(ctx, 1, device(deviceID))
+}
+
+func (m *Metrics) recordDecodeFailure(ctx context.Context, deviceID string) {
+	if m == nil {
+		return
+	}
+	m.decodeFailures.Add(ctx, 1, device(deviceID))
+}
+
+func (m *Metrics) recordScanFailure(ctx context.Context) {
+	if m == nil {
+		return
+	}
+	m.scanFailures.Add(ctx, 1)
+}
+
+func (m *Metrics) recordDropped(ctx context.Context, deviceID string) {
+	if m == nil {
+		return
+	}
+	m.dropped.Add(ctx, 1, device(deviceID))
+}
+
+// RecordInsert reports the outcome of writing one reading to the database.
+func (m *Metrics) RecordInsert(ctx context.Context, deviceID string, err error) {
+	if m == nil {
+		return
+	}
+
+	if err != nil {
+		m.insertErrors.Add(ctx, 1, device(deviceID))
+		return
+	}
+
+	m.inserts.Add(ctx, 1, device(deviceID))
+}


### PR DESCRIPTION
Adds Victron collection to this process, using [go-victron-ble](https://github.com/alpineworks/go-victron-ble) and the manufacturer data now reported by go-litime-bluetooth v1.2.0.

## Why in this process

Victron broadcasts its state in the advertisement, so reading it is passive — no connection, no pairing, no GATT. But it still requires *scanning*, and scanning is what aborts connections: a scan starting while another caller is mid-connect kills it with `le-connection-abort-by-local`. That is the bug fixed in go-litime-bluetooth v1.1.2, by serialising scanning and connecting behind one per-adapter lock.

That lock lives inside a process. A separate `victron-timescaledb-inserter` would scan on its own schedule, outside it, and reintroduce exactly the failure that took collection down for most of a day.

So the collector takes the battery manager's adapter via `Manager.Adapter()`, and its scans queue against battery connections rather than interrupting them.

## Configuration

```sh
VICTRON_DEVICES="smartsolar=F9:E3:C4:6E:85:D9"
VICTRON_KEYS="smartsolar=<advertisement key>"
```

Unset means Victron collection is simply disabled.

Devices and keys are separate variables keyed by the same operator-chosen ID. Both must cover every device: one without a key can be seen but never decrypted, and a key naming an unconfigured device is almost always a typo. Both are startup errors rather than a device that is quietly never read.

The key is a credential and belongs in a secret alongside the database password. It is never logged.

## Trade-off worth knowing

Each scan holds the radio, so battery reconnects queue behind it. Defaults are a 5s scan every 60s to keep that window small. `VICTRON_SCAN_DURATION >= VICTRON_SCAN_INTERVAL` is rejected at startup — otherwise the radio is never free, which would present as batteries mysteriously failing to reconnect rather than as a misconfiguration.

## Data

Migration `005` creates `sensors.victron`. Readings are stored as NULL where the device reported a field unavailable, since a charger reporting nothing and a charger reporting no output are different states.

Metrics are per device. `victron_missed` counts scans producing nothing for a configured device — with no connection to lose, absence of readings is the only evidence a passive collector has lost sight of something, so that is the one to alert on.

## Testing

- Builds for darwin and linux/arm64; tests pass under `-race` on both; `go vet`, `gofmt` and `golangci-lint` v2.1.6 clean
- Migration 005 and the insert query were run against the live TimescaleDB inside a rolled-back transaction, covering both a fully-populated row and one with every optional reading NULL
- The decode path itself is verified upstream: `go-victron-ble` was checked against this exact charger, where its decoded battery voltage matched the independently measured series sum of the two batteries to within 0.3%

**Not yet run end to end on hardware.** The scan-and-decode loop has not executed against a live adapter, so the deployment is the first real test of the collector, as opposed to the decoding it depends on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)