### PR TITLE
fix: grant grafana read access to sensors.victron

### DIFF
--- a/docker/timescale/migrations/005_create_victron_table.up.sql
+++ b/docker/timescale/migrations/005_create_victron_table.up.sql
@@ -29,3 +29,16 @@ SELECT
 
 -- Almost every query is "this device, recent first".
 CREATE INDEX IF NOT EXISTS victron_device_id_time_idx ON sensors.victron (device_id, time DESC);
+
+-- The grafana role reads these tables, and a grant per table is easy to forget:
+-- sensors.victron was created without one, so the dashboard queried a table it
+-- could not see. Grant it, and set the default so later tables are covered
+-- without anyone having to remember.
+GRANT
+SELECT
+    ON sensors.victron TO grafana;
+
+ALTER DEFAULT PRIVILEGES IN SCHEMA sensors
+GRANT
+SELECT
+    ON TABLES TO grafana;


### PR DESCRIPTION
`sensors.victron` was created without a grant for the `grafana` role, so the new dashboard queries a table it cannot see.

Every other table in the schema has one:

```
birdnet, bme280, litime, pmsa003i, renogychargecontroller,
tsl2561, vantagepro2plus, veml7700   -> grafana SELECT
victron                              -> (none)
```

```
can_read_victron | can_read_litime | schema_usage
f                | t               | t
```

## Change

Grants `SELECT` on `sensors.victron`, and adds `ALTER DEFAULT PRIVILEGES` for the schema so later tables are covered without anyone having to remember. This gap would otherwise recur with every new sensor, and it fails as an *empty dashboard* rather than as a permissions error anyone would recognise.

## Applied and verified

Already applied to the live database, and checked by reading as the role rather than by inspecting the grant:

```sql
SET ROLE grafana;
SELECT device_id, count(*), max(time) FROM victron GROUP BY 1;
-- smartsolar | 14 | 2026-07-28 00:37:56+00
```

That also confirms the hypertable's chunks are covered, not just the parent table.

This PR keeps the migration able to reproduce it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)