### PR TITLE
feat: collect from victron battery monitors

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,16 +66,33 @@ go run ./example/multi
 Addresses are MAC addresses on Linux but opaque CoreBluetooth UUIDs on macOS, so
 a value discovered on one operating system will not work on another.
 
-### Victron solar chargers
+### Victron devices
 
 Victron devices broadcast their state in the BLE advertisement rather than
 exposing it over a connection, so reading them is passive — no connection, no
-pairing, no GATT:
+pairing, no GATT. The device's Bluetooth PIN is therefore irrelevant here; it
+gates connecting with VictronConnect, which this never does.
 
 ```sh
-VICTRON_DEVICES="smartsolar=F9:E3:C4:6E:85:D9"
-VICTRON_KEYS="smartsolar=<advertisement key>"
+VICTRON_DEVICES="smartsolar=F9:E3:C4:6E:85:D9,shunt=F1:8C:29:05:9D:BA"
+VICTRON_KEYS="smartsolar=<advertisement key>,shunt=<advertisement key>"
 ```
+
+Two record types are decoded, each written to its own table:
+
+| Record | Devices | Table |
+| --- | --- | --- |
+| `0x01` solar charger | SmartSolar, BlueSolar MPPT | `sensors.victron` |
+| `0x02` battery monitor | SmartShunt, BMV-7xx | `sensors.victron_battery_monitor` |
+
+Any other record type is logged at debug and counted by
+`victron_unsupported_records`; it does not count as a missing device.
+
+**Instant Readout must be switched on per device**, under the same settings
+screen as the key below. A device with it disabled still advertises — a four
+byte header carrying its model and nothing else — so it looks present in a scan
+while never producing a reading. That reads as a missing device here, which is
+the intended signal.
 
 The advertisement key comes from VictronConnect: select the device, then
 **Settings → Product Info → Instant Readout Details → Show**. It is a credential
@@ -90,12 +107,23 @@ always a typo, so both are startup errors rather than silent omissions.
 Scanning shares the radio with the batteries and is serialised against their
 connections, which is why this runs in the same process rather than beside it.
 Each scan holds the radio, so battery reconnects queue behind it — keep
-`VICTRON_SCAN_DURATION` short relative to `VICTRON_SCAN_INTERVAL`. Readings land
-in `sensors.victron`.
+`VICTRON_SCAN_DURATION` short relative to `VICTRON_SCAN_INTERVAL`. Adding
+devices to an existing scan is free: the scan already runs and filters by
+address, so a second or third device costs no extra radio time.
 
 Because there is no connection to lose, the only sign that a Victron device has
 gone quiet is the absence of readings; `victron_missed` counts scans that
 produced nothing for a configured device and is the metric worth alerting on.
+It means "this device is not transmitting readable state" and nothing else — a
+record type with no parser, or a payload that fails to decrypt, does not
+increment it, because in both cases the device is plainly alive and pointing at
+a radio problem would waste the reader's time.
+
+A newly installed SmartShunt reports `state_of_charge`, `consumed_ah`, and
+`time_to_go_minutes` as NULL until it has seen a full charge or been
+synchronised by hand in VictronConnect. That is the device declining to guess
+rather than a fault, and it is why those columns are nullable: storing the
+unavailable sentinel as `0` would read as a flat battery.
 
 ### WiFi and Bluetooth on a Raspberry Pi
 
@@ -171,10 +199,21 @@ question is usually whether one of them has quietly died:
 
 Battery readings land in `sensors.litime`, a hypertable keyed on `time` with a
 `battery_id` column identifying the source. Rows written before multi-battery
-support are backfilled as `unknown`. Victron readings land in `sensors.victron`,
-keyed on `time` with a `device_id`.
+support are backfilled as `unknown`.
 
-Both are defined in
+Victron readings are split by record type, both keyed on `time` with a
+`device_id`: solar chargers to `sensors.victron`, battery monitors to
+`sensors.victron_battery_monitor`. They are separate tables because the two
+record types share only `battery_voltage` — everything else one reports, the
+other does not.
+
+On the battery monitor table, `aux_value` is stored beside `aux_input_type`
+because the shunt's auxiliary input can be a starter battery, a series-string
+midpoint, or a temperature sensor. The unit changes with it — volts in two
+cases, degrees celsius in the third — so the number is uninterpretable without
+the type.
+
+All are defined in
 [lfprocks/timescale-migrations](https://github.com/lfprocks/timescale-migrations),
 which is the single source of truth for the `sensors` schema and what migrates
 the live database. This repository does **not** carry its own copy — two files

--- a/cmd/litime-timescaledb-inserter/victron.go
+++ b/cmd/litime-timescaledb-inserter/victron.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"time"
 
+	victronble "alpineworks.io/go-victron-ble"
 	"github.com/michaelpeterswa/litime-timescaledb-inserter/internal/config"
 	"github.com/michaelpeterswa/litime-timescaledb-inserter/internal/timescale"
 	"github.com/michaelpeterswa/litime-timescaledb-inserter/internal/victron"
@@ -80,6 +81,11 @@ func startVictron(
 
 // insertVictron writes one reading, using a background context so that readings
 // still queued at shutdown are not abandoned mid-write.
+//
+// Record types go to different tables, so this dispatches on which payload the
+// collector filled in rather than on RecordType: the pointer is what the rest
+// of the function actually needs, and checking it removes any way for the two
+// to disagree.
 func insertVictron(
 	ctx context.Context,
 	client *timescale.TimescaleClient,
@@ -90,32 +96,54 @@ func insertVictron(
 	insertCtx, cancel := context.WithTimeout(context.WithoutCancel(ctx), timeout)
 	defer cancel()
 
+	switch {
+	case reading.SolarCharger != nil:
+		insertSolarCharger(insertCtx, client, metrics, reading)
+	case reading.BatteryMonitor != nil:
+		insertBatteryMonitor(insertCtx, client, metrics, reading)
+	default:
+		// The collector does not publish a reading without a payload, so this
+		// is a programming error rather than a device fault.
+		slog.Error("victron reading carried no payload",
+			slog.String("device_id", reading.DeviceID),
+			slog.Int("record_type", int(reading.RecordType)))
+	}
+}
+
+func insertSolarCharger(
+	ctx context.Context,
+	client *timescale.TimescaleClient,
+	metrics *victron.Metrics,
+	reading victron.Reading,
+) {
+	charger := reading.SolarCharger
+
 	measure := timescale.VictronMeasurement{
 		DeviceID:               reading.DeviceID,
 		ObservedAt:             reading.ObservedAt,
 		ModelID:                reading.ModelID,
 		ModelName:              reading.ModelName,
 		RecordType:             reading.RecordType,
-		BatteryVoltage:         reading.Data.BatteryVoltage,
-		BatteryChargingCurrent: reading.Data.BatteryChargingCurrent,
-		YieldToday:             reading.Data.YieldToday,
-		SolarPower:             reading.Data.SolarPower,
-		ExternalDeviceLoad:     reading.Data.ExternalDeviceLoad,
+		BatteryVoltage:         charger.BatteryVoltage,
+		BatteryChargingCurrent: charger.BatteryChargingCurrent,
+		YieldToday:             charger.YieldToday,
+		SolarPower:             charger.SolarPower,
+		ExternalDeviceLoad:     charger.ExternalDeviceLoad,
 	}
 
 	// The enums are stored as text so the table reads without a lookup, and
 	// stay NULL when the device reported the field as unavailable.
-	if reading.Data.ChargeState != nil {
-		state := reading.Data.ChargeState.String()
+	if charger.ChargeState != nil {
+		state := charger.ChargeState.String()
 		measure.ChargeState = &state
 	}
-	if reading.Data.ChargerError != nil {
-		chargerErr := reading.Data.ChargerError.String()
+	if charger.ChargerError != nil {
+		chargerErr := charger.ChargerError.String()
 		measure.ChargerError = &chargerErr
 	}
 
-	err := client.InsertVictron(insertCtx, measure)
-	metrics.RecordInsert(insertCtx, reading.DeviceID, err)
+	err := client.InsertVictron(ctx, measure)
+	metrics.RecordInsert(ctx, reading.DeviceID, err)
 
 	if err != nil {
 		slog.Error("failed to insert victron data into timescale",
@@ -126,6 +154,77 @@ func insertVictron(
 
 	slog.Debug("inserted victron reading",
 		slog.String("device_id", reading.DeviceID),
-		slog.Any("solar_power", reading.Data.SolarPower),
-		slog.Any("battery_voltage", reading.Data.BatteryVoltage))
+		slog.Any("solar_power", charger.SolarPower),
+		slog.Any("battery_voltage", charger.BatteryVoltage))
+}
+
+func insertBatteryMonitor(
+	ctx context.Context,
+	client *timescale.TimescaleClient,
+	metrics *victron.Metrics,
+	reading victron.Reading,
+) {
+	monitor := reading.BatteryMonitor
+
+	measure := timescale.VictronBatteryMonitorMeasurement{
+		DeviceID:       reading.DeviceID,
+		ObservedAt:     reading.ObservedAt,
+		ModelID:        reading.ModelID,
+		ModelName:      reading.ModelName,
+		RecordType:     reading.RecordType,
+		BatteryVoltage: monitor.BatteryVoltage,
+		BatteryCurrent: monitor.BatteryCurrent,
+		StateOfCharge:  monitor.StateOfCharge,
+		ConsumedAh:     monitor.ConsumedAh,
+		AuxInputType:   monitor.AuxInputType.String(),
+		AuxValue:       auxValue(monitor),
+	}
+
+	// Stored in minutes because that is the resolution the device sends; a
+	// finer unit would imply precision the reading does not have.
+	if monitor.TimeToGo != nil {
+		minutes := int32(monitor.TimeToGo.Minutes())
+		measure.TimeToGoMinutes = &minutes
+	}
+
+	// NULL rather than "none" when nothing is wrong, so that finding trouble is
+	// a NULL check rather than a string comparison.
+	if monitor.AlarmReason.Active() {
+		alarm := monitor.AlarmReason.String()
+		measure.AlarmReason = &alarm
+	}
+
+	err := client.InsertVictronBatteryMonitor(ctx, measure)
+	metrics.RecordInsert(ctx, reading.DeviceID, err)
+
+	if err != nil {
+		slog.Error("failed to insert victron battery monitor data into timescale",
+			slog.String("device_id", reading.DeviceID),
+			slog.String("error", err.Error()))
+		return
+	}
+
+	slog.Debug("inserted victron battery monitor reading",
+		slog.String("device_id", reading.DeviceID),
+		slog.Any("battery_voltage", monitor.BatteryVoltage),
+		slog.Any("battery_current", monitor.BatteryCurrent),
+		slog.Any("state_of_charge", monitor.StateOfCharge))
+}
+
+// auxValue picks whichever aux reading the device populated.
+//
+// The library exposes the three as separate typed fields precisely so volts and
+// degrees cannot be confused; flattening them into one column here is safe only
+// because aux_input_type is stored alongside and says which this is.
+func auxValue(monitor *victronble.BatteryMonitor) *float64 {
+	switch {
+	case monitor.StarterVoltage != nil:
+		return monitor.StarterVoltage
+	case monitor.MidpointVoltage != nil:
+		return monitor.MidpointVoltage
+	case monitor.Temperature != nil:
+		return monitor.Temperature
+	default:
+		return nil
+	}
 }

--- a/go.mod
+++ b/go.mod
@@ -6,7 +6,7 @@ toolchain go1.24.2
 
 require (
 	alpineworks.io/go-litime-bluetooth v1.2.0
-	alpineworks.io/go-victron-ble v1.0.0
+	alpineworks.io/go-victron-ble v1.1.0
 	alpineworks.io/ootel v1.0.4
 	github.com/caarlos0/env/v11 v11.3.1
 	github.com/exaring/otelpgx v0.9.3

--- a/go.sum
+++ b/go.sum
@@ -2,6 +2,8 @@ alpineworks.io/go-litime-bluetooth v1.2.0 h1:K0/273ywHwk2bwJ9LNJ0R/2IugMkfeles2+
 alpineworks.io/go-litime-bluetooth v1.2.0/go.mod h1:hmAPqfWiWDfnHssR8XurZl6kX3RdAAo6iMCnr63YytE=
 alpineworks.io/go-victron-ble v1.0.0 h1:zhay5wb2URttQatrOBI3U6+m3P5UYJcFhHgY4sN+GAI=
 alpineworks.io/go-victron-ble v1.0.0/go.mod h1:3NjpS2G8z3lVaEQ9JVB2VkYjaaNYpgJNOPnAOiOoNrw=
+alpineworks.io/go-victron-ble v1.1.0 h1:aNw4afYVsa55kDgjlbV64VT5HYv2oendkJuf81mr2dQ=
+alpineworks.io/go-victron-ble v1.1.0/go.mod h1:3NjpS2G8z3lVaEQ9JVB2VkYjaaNYpgJNOPnAOiOoNrw=
 alpineworks.io/ootel v1.0.4 h1:NZrYyFsk8obdfhbs0g1+XPXotLdrLO+iJfFRQvfkdfM=
 alpineworks.io/ootel v1.0.4/go.mod h1:ZCKCBy2Q0wVPO03iSSTfbv+GcL/5lU0d+SPH8hTwd3k=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=

--- a/internal/timescale/queries/insert_victron_battery_monitor.pgsql
+++ b/internal/timescale/queries/insert_victron_battery_monitor.pgsql
@@ -1,0 +1,32 @@
+INSERT INTO
+    sensors.victron_battery_monitor (
+        time,
+        device_id,
+        model_id,
+        model_name,
+        record_type,
+        battery_voltage,
+        battery_current,
+        state_of_charge,
+        consumed_ah,
+        time_to_go_minutes,
+        alarm_reason,
+        aux_input_type,
+        aux_value
+    )
+VALUES
+    (
+        $1,
+        $2,
+        $3,
+        $4,
+        $5,
+        $6,
+        $7,
+        $8,
+        $9,
+        $10,
+        $11,
+        $12,
+        $13
+    );

--- a/internal/timescale/timescale.go
+++ b/internal/timescale/timescale.go
@@ -128,6 +128,67 @@ func (c *TimescaleClient) InsertVictron(ctx context.Context, measure VictronMeas
 	return nil
 }
 
+//go:embed queries/insert_victron_battery_monitor.pgsql
+var insertVictronBatteryMonitor string
+
+// VictronBatteryMonitorMeasurement is one decoded Victron battery monitor
+// advertisement -- a BMV-7xx or a SmartShunt.
+//
+// It goes to its own table rather than sharing sensors.victron: of everything a
+// battery monitor reports, only BatteryVoltage means the same thing as it does
+// for a solar charger.
+//
+// As with VictronMeasurement the readings are pointers, and the distinction
+// matters more here. A shunt that has not been synchronised reports no state of
+// charge at all until it has seen a full charge; storing that as 0 would read
+// as a flat battery rather than as an unknown one.
+type VictronBatteryMonitorMeasurement struct {
+	DeviceID   string
+	ObservedAt time.Time
+	ModelID    uint16
+	ModelName  string
+	RecordType uint8
+
+	BatteryVoltage *float64
+	// BatteryCurrent is positive into the battery, negative out of it.
+	BatteryCurrent  *float64
+	StateOfCharge   *float64
+	ConsumedAh      *float64
+	TimeToGoMinutes *int32
+	// AlarmReason is nil when no alarm is active, rather than a string saying
+	// so, so that "is anything wrong" is a NULL check rather than a comparison
+	// against a magic value.
+	AlarmReason *string
+	// AuxInputType is always recorded, including when nothing is wired to the
+	// aux input, because it is what makes AuxValue interpretable at all.
+	AuxInputType string
+	AuxValue     *float64
+}
+
+// InsertVictronBatteryMonitor records one battery monitor reading.
+func (c *TimescaleClient) InsertVictronBatteryMonitor(ctx context.Context, measure VictronBatteryMonitorMeasurement) error {
+	_, err := c.Pool.Exec(ctx, insertVictronBatteryMonitor,
+		measure.ObservedAt,
+		measure.DeviceID,
+		int32(measure.ModelID),
+		measure.ModelName,
+		int16(measure.RecordType),
+		measure.BatteryVoltage,
+		measure.BatteryCurrent,
+		measure.StateOfCharge,
+		measure.ConsumedAh,
+		measure.TimeToGoMinutes,
+		measure.AlarmReason,
+		measure.AuxInputType,
+		measure.AuxValue,
+	)
+	if err != nil {
+		return fmt.Errorf("insert victron battery monitor data: %w", err)
+	}
+
+	return nil
+}
+
 func mapCellVoltages(cellVoltages []float32) map[string]float32 {
 	voltages := make(map[string]float32, len(cellVoltages))
 	for i, voltage := range cellVoltages {

--- a/internal/victron/collector.go
+++ b/internal/victron/collector.go
@@ -14,14 +14,20 @@ import (
 	tinygobluetooth "tinygo.org/x/bluetooth"
 )
 
-// Reading is one decoded solar charger advertisement.
+// Reading is one decoded Victron advertisement.
+//
+// Record types report almost disjoint fields, so the payload is a variant
+// rather than one struct with everything on it: exactly one of the pointers
+// below is set, chosen by RecordType. They go to different tables.
 type Reading struct {
 	DeviceID   string
 	ObservedAt time.Time
 	ModelID    uint16
 	ModelName  string
 	RecordType uint8
-	Data       *victronble.SolarCharger
+
+	SolarCharger   *victronble.SolarCharger
+	BatteryMonitor *victronble.BatteryMonitor
 }
 
 // CollectorOptions configures a Collector.
@@ -193,7 +199,19 @@ func (c *Collector) scanOnce(ctx context.Context) {
 	}
 }
 
-// handle decodes one scan result, reporting whether a reading was published.
+// handle decodes one scan result, reporting whether the device was seen
+// broadcasting instant readout.
+//
+// That return value feeds the missed counter, so it means "this device is
+// advertising readable state", not "a reading was published". A record type
+// this build cannot parse still means the device is alive and transmitting,
+// and counting it as missing would point at the wrong problem entirely.
+//
+// A record that fails to parse as instant readout deliberately does NOT count
+// as seen. That is the shape a device advertises when instant readout is
+// switched off in VictronConnect: a four byte header carrying the model and
+// nothing else. It is indistinguishable from silence as far as data goes, so
+// the missed counter should fire and say so.
 func (c *Collector) handle(ctx context.Context, device Device, found litimebluetooth.DiscoveredDevice) bool {
 	data, ok := found.ManufacturerData[victronble.CompanyID]
 	if !ok {
@@ -210,11 +228,14 @@ func (c *Collector) handle(ctx context.Context, device Device, found litimebluet
 		return false
 	}
 
-	if record.Type != victronble.RecordSolarCharger {
+	switch record.Type {
+	case victronble.RecordSolarCharger, victronble.RecordBatteryMonitor:
+	default:
 		c.logger.Debug("ignoring unsupported victron record type",
 			slog.String("device_id", device.ID),
 			slog.String("record_type", record.Type.String()))
-		return false
+		c.metrics.recordUnsupported(ctx, device.ID, record.Type.String())
+		return true
 	}
 
 	payload, err := victronble.Decrypt(record, device.Key)
@@ -232,16 +253,9 @@ func (c *Collector) handle(ctx context.Context, device Device, found litimebluet
 				slog.String("error", err.Error()))
 		}
 		c.metrics.recordDecryptFailure(ctx, device.ID)
-		return false
-	}
-
-	charger, err := victronble.ParseSolarCharger(payload)
-	if err != nil {
-		c.logger.Warn("failed to parse victron payload",
-			slog.String("device_id", device.ID),
-			slog.String("error", err.Error()))
-		c.metrics.recordDecodeFailure(ctx, device.ID)
-		return false
+		// Still seen: a wrong key is a configuration fault, not a quiet device,
+		// and decryptFailures already says so precisely.
+		return true
 	}
 
 	modelName, _ := victronble.ModelName(record.ModelID)
@@ -252,7 +266,32 @@ func (c *Collector) handle(ctx context.Context, device Device, found litimebluet
 		ModelID:    record.ModelID,
 		ModelName:  modelName,
 		RecordType: uint8(record.Type),
-		Data:       charger,
+	}
+
+	switch record.Type {
+	case victronble.RecordSolarCharger:
+		charger, err := victronble.ParseSolarCharger(payload)
+		if err != nil {
+			c.logger.Warn("failed to parse victron payload",
+				slog.String("device_id", device.ID),
+				slog.String("record_type", record.Type.String()),
+				slog.String("error", err.Error()))
+			c.metrics.recordDecodeFailure(ctx, device.ID)
+			return true
+		}
+		reading.SolarCharger = charger
+
+	case victronble.RecordBatteryMonitor:
+		monitor, err := victronble.ParseBatteryMonitor(payload)
+		if err != nil {
+			c.logger.Warn("failed to parse victron payload",
+				slog.String("device_id", device.ID),
+				slog.String("record_type", record.Type.String()),
+				slog.String("error", err.Error()))
+			c.metrics.recordDecodeFailure(ctx, device.ID)
+			return true
+		}
+		reading.BatteryMonitor = monitor
 	}
 
 	if !c.publish(reading) {

--- a/internal/victron/collector_test.go
+++ b/internal/victron/collector_test.go
@@ -1,0 +1,179 @@
+package victron
+
+import (
+	"context"
+	"crypto/aes"
+	"encoding/binary"
+	"encoding/hex"
+	"io"
+	"log/slog"
+	"testing"
+
+	litimebluetooth "alpineworks.io/go-litime-bluetooth/bluetooth"
+	victronble "alpineworks.io/go-victron-ble"
+)
+
+// handle's return value feeds the missed counter, and the two questions it sits
+// between are easy to conflate: "is this device transmitting" and "did we get a
+// reading out of it". These tests pin the difference, because getting it wrong
+// is silent -- a working device reported as absent, or a device with instant
+// readout switched off reported as healthy.
+
+func TestHandleBatteryMonitorPublishesReading(t *testing.T) {
+	t.Parallel()
+
+	collector, device := testCollector(t)
+
+	// A real capture from a SmartShunt IP65 300A: 26.60 V, midpoint aux.
+	payload := decodeHex(t, "ffff640a0000320531fcffffffffff")
+	found := advertisement(t, device, 0xC039, victronble.RecordBatteryMonitor, payload)
+
+	if seen := collector.handle(context.Background(), device, found); !seen {
+		t.Fatal("handle reported the device as not seen")
+	}
+
+	select {
+	case reading := <-collector.readings:
+		if reading.BatteryMonitor == nil {
+			t.Fatal("reading carried no battery monitor payload")
+		}
+		if reading.SolarCharger != nil {
+			t.Error("reading carried a solar charger payload as well")
+		}
+		if reading.ModelName != "SmartShunt IP65 300A/50mV" {
+			t.Errorf("model name = %q", reading.ModelName)
+		}
+		if v := reading.BatteryMonitor.BatteryVoltage; v == nil || *v != 26.60 {
+			t.Errorf("battery voltage = %v, want 26.60", v)
+		}
+		if reading.BatteryMonitor.AuxInputType != victronble.AuxInputMidpointVoltage {
+			t.Errorf("aux input type = %v, want midpoint", reading.BatteryMonitor.AuxInputType)
+		}
+	default:
+		t.Fatal("nothing was published")
+	}
+}
+
+// A record type with no parser still means the device is alive and
+// transmitting. Counting it as missed sends whoever reads the metric looking
+// for a radio problem that does not exist.
+func TestHandleUnsupportedRecordTypeCountsAsSeen(t *testing.T) {
+	t.Parallel()
+
+	collector, device := testCollector(t)
+
+	found := advertisement(t, device, 0xA381, victronble.RecordInverter, make([]byte, 12))
+
+	if seen := collector.handle(context.Background(), device, found); !seen {
+		t.Error("an unsupported record type was reported as a missing device")
+	}
+
+	select {
+	case reading := <-collector.readings:
+		t.Fatalf("published a reading for an undecodable record type: %+v", reading)
+	default:
+	}
+}
+
+// The opposite case, and the reason the distinction is not simply "did we see
+// any Victron bytes": a device with instant readout switched off advertises a
+// four byte header carrying its model and nothing else. No data will ever come
+// from it, so it must read as missing rather than as healthy.
+func TestHandleWithoutInstantReadoutCountsAsMissed(t *testing.T) {
+	t.Parallel()
+
+	collector, device := testCollector(t)
+
+	// Captured from the SmartShunt before instant readout was enabled.
+	found := litimebluetooth.DiscoveredDevice{
+		ManufacturerData: map[uint16][]byte{victronble.CompanyID: decodeHex(t, "100239c0")},
+	}
+
+	if seen := collector.handle(context.Background(), device, found); seen {
+		t.Error("a device advertising no instant readout was reported as seen")
+	}
+}
+
+func TestHandleIgnoresNonVictronAdvertisement(t *testing.T) {
+	t.Parallel()
+
+	collector, device := testCollector(t)
+
+	found := litimebluetooth.DiscoveredDevice{
+		ManufacturerData: map[uint16][]byte{0x004C: {1, 2, 3}},
+	}
+
+	if seen := collector.handle(context.Background(), device, found); seen {
+		t.Error("a non-Victron advertisement was reported as a Victron sighting")
+	}
+}
+
+func testCollector(t *testing.T) (*Collector, Device) {
+	t.Helper()
+
+	key, err := victronble.ParseKey(testKey)
+	if err != nil {
+		t.Fatalf("ParseKey: %v", err)
+	}
+
+	device := Device{ID: "shunt", Address: "F1:8C:29:05:9D:BA", Key: key}
+
+	collector := &Collector{
+		devices:   []Device{device},
+		byAddress: map[string]Device{device.Address: device},
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		readings:  make(chan Reading, 1),
+	}
+
+	return collector, device
+}
+
+// advertisement builds the manufacturer data a device would broadcast for the
+// given payload, encrypting it the way the device does so the test exercises
+// the real decrypt path rather than bypassing it.
+func advertisement(t *testing.T, device Device, modelID uint16, recordType victronble.RecordType, payload []byte) litimebluetooth.DiscoveredDevice {
+	t.Helper()
+
+	const iv uint16 = 0x0123
+
+	block, err := aes.NewCipher(device.Key)
+	if err != nil {
+		t.Fatalf("cipher: %v", err)
+	}
+
+	counter := make([]byte, aes.BlockSize)
+	binary.LittleEndian.PutUint16(counter, iv)
+
+	keystream := make([]byte, aes.BlockSize)
+	block.Encrypt(keystream, counter)
+
+	if len(payload) > aes.BlockSize {
+		t.Fatalf("test payload of %d bytes spans more than one AES block", len(payload))
+	}
+
+	data := make([]byte, 8, 8+len(payload))
+	binary.LittleEndian.PutUint16(data[0:], 0x0210)
+	binary.LittleEndian.PutUint16(data[2:], modelID)
+	data[4] = byte(recordType)
+	binary.LittleEndian.PutUint16(data[5:], iv)
+	data[7] = device.Key[0]
+
+	for i, b := range payload {
+		data = append(data, b^keystream[i])
+	}
+
+	return litimebluetooth.DiscoveredDevice{
+		ManufacturerData: map[uint16][]byte{victronble.CompanyID: data},
+	}
+}
+
+func decodeHex(t *testing.T, s string) []byte {
+	t.Helper()
+
+	data, err := hex.DecodeString(s)
+	if err != nil {
+		t.Fatalf("bad fixture %q: %v", s, err)
+	}
+
+	return data
+}

--- a/internal/victron/metrics.go
+++ b/internal/victron/metrics.go
@@ -18,6 +18,7 @@ const meterName = "github.com/michaelpeterswa/litime-timescaledb-inserter/victro
 type Metrics struct {
 	readings        metric.Int64Counter
 	missed          metric.Int64Counter
+	unsupported     metric.Int64Counter
 	decryptFailures metric.Int64Counter
 	decodeFailures  metric.Int64Counter
 	scanFailures    metric.Int64Counter
@@ -43,6 +44,7 @@ func NewMetrics() (*Metrics, error) {
 	m := &Metrics{
 		readings:        counter("victron.readings", "Advertisements decoded from a Victron device"),
 		missed:          counter("victron.missed", "Scans that produced no advertisement for a configured device"),
+		unsupported:     counter("victron.unsupported_records", "Advertisements from a record type this build cannot decode"),
 		decryptFailures: counter("victron.decrypt_failures", "Advertisements that could not be decrypted"),
 		decodeFailures:  counter("victron.decode_failures", "Advertisements that decrypted but could not be parsed"),
 		scanFailures:    counter("victron.scan_failures", "Scans that failed outright"),
@@ -76,6 +78,20 @@ func (m *Metrics) recordMissed(ctx context.Context, deviceID string) {
 		return
 	}
 	m.missed.Add(ctx, 1, device(deviceID))
+}
+
+// recordUnsupported reports a device broadcasting a record type this build has
+// no parser for. It is deliberately separate from missed: the device is alive
+// and transmitting, so counting it as absent would send anyone reading the
+// metric looking for a radio problem that does not exist.
+func (m *Metrics) recordUnsupported(ctx context.Context, deviceID, recordType string) {
+	if m == nil {
+		return
+	}
+	m.unsupported.Add(ctx, 1, metric.WithAttributes(
+		attribute.String("device_id", deviceID),
+		attribute.String("record_type", recordType),
+	))
 }
 
 func (m *Metrics) recordDecryptFailure(ctx context.Context, deviceID string) {


### PR DESCRIPTION
A SmartShunt IP65 300A now sits on the battery bank alongside the SmartSolar charger, broadcasting Victron record type `0x02`. [go-victron-ble v1.1.0](https://github.com/alpineworks/go-victron-ble/pull/1) decodes it; this consumes that.

Depends on [lfprocks/timescale-migrations#5](https://github.com/lfprocks/timescale-migrations/pull/5) (merged, applied) for `sensors.victron_battery_monitor`.

## Two tables, one collector

`Reading` becomes a variant — exactly one of `SolarCharger` or `BatteryMonitor` is set — because the record types share only `battery_voltage`. `insertVictron` dispatches on **which payload is present** rather than on `RecordType`, so the two cannot disagree.

`aux_value` is written alongside `aux_input_type`. The library exposes the three aux readings as separate typed fields precisely so volts and °C can't be confused; flattening them into one column is safe only because the type travels with the value.

## The counting bug

`handle()`'s return value feeds `victron_missed`, documented as *"scans that produced no advertisement for a configured device"*. It returned `false` for any record type without a parser — so a device that was plainly alive and transmitting got counted as **absent**.

Nothing noticed, because only one record type had a parser and both configured devices used it. Adding a second type is exactly when it would have started lying: a metric pointing at a radio problem that doesn't exist.

Now:

| Situation | Seen? | Also counted by |
| --- | --- | --- |
| Decoded a reading | yes | `victron_readings` |
| Record type with no parser | yes | `victron_unsupported_records` (new) |
| Decrypt failed (wrong key) | yes | `victron_decrypt_failures` |
| Payload failed to parse | yes | `victron_decode_failures` |
| Instant readout switched off | **no** | `victron_missed` |
| Not a Victron advertisement | **no** | — |

That last-but-one row is the case worth preserving deliberately. A device with Instant Readout disabled still advertises — a four-byte header carrying its model and nothing else. No data will ever come from it, so it must keep reading as missing. This is not hypothetical: it is exactly how the SmartShunt presented before the setting was enabled, and it's why "did we see any Victron bytes" is the wrong question.

## Tests

Four cases in `internal/victron/collector_test.go`, building real AES-CTR-encrypted advertisements so the decrypt path is exercised rather than bypassed. The battery-monitor case uses a genuine capture from the shunt.

I verified the tests actually detect the bug rather than merely passing: reverting the fix fails `TestHandleUnsupportedRecordTypeCountsAsSeen` with *"an unsupported record type was reported as a missing device"*, and restoring it passes.

The tests deliberately don't populate `DiscoveredDevice.Address` — `handle` never reads it (address matching happens in `scanOnce`), and `ParseAddress` rejects MACs on darwin, where tinygo addresses are CoreBluetooth UUIDs.

## Checks

`gofmt`, `go build`, `go vet`, `go test ./...` all pass.

I could **not** run `golangci-lint` locally: my Go is 1.26.5 and the installed linter is built with go1.25, so it panics with `file requires newer Go version go1.26`. That's a local toolchain mismatch, not a code issue — CI pins go1.24.x, so please confirm the lint job there rather than taking my word for it.

## Deploying

Once merged and the image is published, the Pi needs `VICTRON_DEVICES` to gain `shunt=F1:8C:29:05:9D:BA`, the key added to the sops-encrypted env, and the image pin bumped — a follow-up in `lfprocks/ansible`.

Expect `state_of_charge`, `consumed_ah`, and `time_to_go_minutes` to be NULL at first. The shunt reports them as unavailable until it has seen a full charge or been synchronised by hand in VictronConnect. That is correct behaviour, not a fault.

🤖 Generated with [Claude Code](https://claude.com/claude-code)